### PR TITLE
MV-4638 message priority

### DIFF
--- a/specs/Messaging/openapispec.json
+++ b/specs/Messaging/openapispec.json
@@ -1,5 +1,5 @@
 {
-    "openapi": "3.0.0",
+    "openapi": "3.1.0",
 
     "info": {
         "title": "Messaging",


### PR DESCRIPTION
[MV-4638 - Create public docs for message priority details](https://bandwidth-jira.atlassian.net/browse/MV-4638)

The messaging API now accepts an optional "priority" parameter with possible values "default" and "high". See [V2 Priority Queuing epic](https://bandwidth-jira.atlassian.net/browse/MV-4452) for more details.