### PR TITLE
made generate remove the current specs directory

### DIFF
--- a/sdk-generation/package.json
+++ b/sdk-generation/package.json
@@ -11,7 +11,7 @@
     "fs-extra": "^9.0.1"
   },
   "scripts": {
-    "generate": "cp -R ../external/specs . && node ./out/generate.js",
+    "generate": "rm -rf ./specs && cp -R ../external/specs . && node ./out/generate.js",
     "lint": "eslint \"./src/**/*.ts\" --fix",
     "build": "npm run lint && tsc --sourcemap"
   },


### PR DESCRIPTION
## For the Committer

All PRs on this repo that change any API sources of truth (markdown files, OpenAPI specs) require a changelog added to the `external/markdown/changelog.md` file. If this PR does not require changelog updates, you need to add the `no-changelog` tag to this PR before opening it.

Please confirm that you have either updated `external/markdown/changelog.md` or added the `no-changelog` tag.
