### PR TITLE
made changelog requirements a bit more reasonable

### DIFF
--- a/.github/workflows/pr-changelog.yaml
+++ b/.github/workflows/pr-changelog.yaml
@@ -1,0 +1,28 @@
+# Deploys the doc site to an S3 bucket
+
+name: PR Publish Docsite
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - 'external/specs/**'
+      - 'external/markdown/voice/bxml/bxmlVerbs/**'
+      - 'external/markdown/voice/bxml/bxmlCallbacks/**'
+      - 'external/markdown/voice/bxml/bxmlAsyncCallbacks/**'
+      - 'external/markdown/messaging/callbacks/**'
+      - 'external/markdown/dashboard/webhooks/**'
+
+jobs:
+  changelog-check:
+    name: Validate changelog
+    runs-on: ubuntu-latest
+    steps:
+    - name: Repo Checkout
+      uses: actions/checkout@v2
+    - name: Confirm Release Notes Update
+      uses: dangoslen/changelog-enforcer@v2
+      with:
+        changeLogPath: 'external/markdown/changelog.md'
+        skipLabels: 'no-changelog'

--- a/.github/workflows/pr-publish-docsite.yaml
+++ b/.github/workflows/pr-publish-docsite.yaml
@@ -19,11 +19,6 @@ jobs:
       uses: actions/checkout@v2
     - name: NPM install
       run: npm install
-    - name: Confirm Release Notes Update
-      uses: dangoslen/changelog-enforcer@v2
-      with:
-        changeLogPath: 'external/markdown/changelog.md'
-        skipLabels: 'no-changelog'
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:


### PR DESCRIPTION
## For the Committer

All PRs on this repo that change any API sources of truth (markdown files, OpenAPI specs) require a changelog added to the `external/markdown/changelog.md` file. If this PR does not require changelog updates, you need to add the `no-changelog` tag to this PR before opening it.

Please confirm that you have either updated `external/markdown/changelog.md` or added the `no-changelog` tag.
