### PR TITLE
DX-2008 added gooder regex for aws bucket names

### DIFF
--- a/.github/workflows/pr-publish-docsite.yaml
+++ b/.github/workflows/pr-publish-docsite.yaml
@@ -40,6 +40,7 @@ jobs:
       run: |
         BUCKET_NAME=bw-api-docs-${GITHUB_HEAD_REF#refs/heads/}
         BUCKET_NAME=$(echo "$BUCKET_NAME" | tr '[:upper:]' '[:lower:]') #convert to lowercase for AWS bucket (can't be uppercase)
+        BUCKET_NAME=$(echo "$BUCKET_NAME" | sed -e "s/[^a-z0-9]/-/g") #replace all remaining non alphanumerics with -
         echo $BUCKET_NAME
         echo "::set-output name=bucket_name::$BUCKET_NAME"
     - name: Create Bucket


### PR DESCRIPTION
## For the Committer

All PRs on this repo that change any API sources of truth (markdown files, OpenAPI specs) require a changelog added to the `external/markdown/changelog.md` file. If this PR does not require changelog updates, you need to add the `no-changelog` tag to this PR before opening it.

Please confirm that you have either updated `external/markdown/changelog.md` or added the `no-changelog` tag.
