### PR TITLE
DX-2003 made changelog its own step

### DIFF
--- a/.github/workflows/pr-changelog.yaml
+++ b/.github/workflows/pr-changelog.yaml
@@ -1,0 +1,22 @@
+# Changelog validation
+
+name: PR Changelog
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - 'site/**'
+
+jobs:
+  changelog_validate:
+    name: Changelog Validate
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Confirm Release Notes Update
+      uses: dangoslen/changelog-enforcer@v2
+      with:
+        changeLogPath: 'site/src/pages/changelog.md'
+        skipLabels: 'no-changelog'

--- a/.github/workflows/pr-publish-docsite.yaml
+++ b/.github/workflows/pr-publish-docsite.yaml
@@ -24,11 +24,6 @@ jobs:
           cd site
           yarn install --frozen-lockfile
           npm run build
-    - name: Confirm Release Notes Update
-      uses: dangoslen/changelog-enforcer@v2
-      with:
-        changeLogPath: 'site/src/pages/changelog.md'
-        skipLabels: 'no-changelog'
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:


### PR DESCRIPTION
## For the Committer

All PRs on this repo that change any API sources of truth (markdown files, OpenAPI specs) require a changelog added to the `external/markdown/changelog.md` file. If this PR does not require changelog updates, you need to add the `no-changelog` tag to this PR before opening it.

Please confirm that you have either updated `external/markdown/changelog.md` or added the `no-changelog` tag.
