### PR TITLE
Update docusaurus.config.js

### DIFF
--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -65,7 +65,7 @@ module.exports = {
           label: 'WebRTC'
         }]
       }, {
-        to: 'docs/',
+        to: 'docs',
         activeBasePath: 'docs',
         label: 'Docs',
         position: 'left',


### PR DESCRIPTION
## For the Committer

All PRs on this repo that change any API sources of truth (markdown files, OpenAPI specs) require a changelog added to the `external/markdown/changelog.md` file. If this PR does not require changelog updates, you need to add the `no-changelog` tag to this PR before opening it.

Please confirm that you have either updated `external/markdown/changelog.md` or added the `no-changelog` tag.
