### PR TITLE
edge 1018 - adding a webhooks page to webrtc

### DIFF
--- a/site/docs/webrtc/webhooks.md
+++ b/site/docs/webrtc/webhooks.md
@@ -16,7 +16,9 @@ import TabItem from "@theme/TabItem";
 
 ## Subscribing to Webhooks
 
-The only API call that allows the registration of a callback / webhook is the POST to the participants resource that is used to create a new participant. The callback/webhook URL is declared in the `POST` to the `https://api.webrtc.bandwidth.com/v1/accounts/{accountId}/participants` endpoint. If the `callbackUrl` property is included in the payload, the value associated with that property is assumed to be a URL. That URL (if found to be valid) will be invoked on events that occur as part of the Participant life cycle.
+### Participant Creation (beta)
+
+The only API call that allows the registration of a callback / webhook is the POST to the participants resource that is used to create a new participant. The callback/webhook URL is declared in the `POST` to the `createParticipants` endpoint. If the `callbackUrl` property is included in the payload, the value associated with that property is assumed to be a URL. That URL (if found to be valid) will be invoked on events that occur as part of the Participant life cycle.
 
 :::note
 Participant event webhooks are currently in Beta, and must be activated by submitting a support ticket to Bandwidth.

--- a/site/docs/webrtc/webhooks.md
+++ b/site/docs/webrtc/webhooks.md
@@ -1,0 +1,65 @@
+---
+id: webhooks
+title: Webhooks
+slug: /webrtc/webhooks
+description: A brief description of the Webhooks registered by WebRTC API calls.
+keywords:
+  - bandwidth
+  - webrtc
+  - video
+  - webhook
+image: ../../static/img/bandwidth-logo.png
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+## Subscribing to Webhooks
+
+The only API call that allows the registration of a callback / webhook is the POST to the participants resource that is used to create a new participant. The callback/webhook URL is declared in the `POST` to the `https://api.webrtc.bandwidth.com/v1/accounts/{accountId}/participants` endpoint. If the `callbackUrl` property is included in the payload, the value associated with that property is assumed to be a URL. That URL (if found to be valid) will be invoked on events that occur as part of the Participant life cycle.
+
+:::note
+Participant event webhooks are currently in Beta, and must be activated by submitting a support ticket to Bandwidth.
+:::
+
+:::note
+Participant event webhooks may change in the future. All attempts will be made to retain the syntax and semantics of the current implementation, but until Bandwidth completes the process of learning with our customers that the implementation is optimal, we cannot assure it. Bandwidth welcomes any and all comments on the implementation while in the Beta phase.
+:::
+
+## Life Cycle Events
+
+The events that will trigger invocation of the specified URL are:
+
+- 'onConnect' - establishment of the websocket connection that will allow the flow of WebRTC Media, an explicit action on the part of the websocket client.
+- 'onDisconnect' - explicit removal of the websocket connection, prompted by explicit server or client action.
+- 'onLeave' - loss of the websocket connection, possibly due to loss of IP connectivity.
+
+## Request Payload
+
+The callback URL will be invoked by Bandwidth when the above events are detected. It will result in a `POST` to the URL specified as the value associated with the `callbackUrl` parameter. The Request Payload parameters that will be included in the `POST` body are...
+
+| Property      | Description                                                                                                       |
+| :------------ | :---------------------------------------------------------------------------------------------------------------- |
+| event         | one of `onConnect`, `onDisconnect` or `onLeave`                                                                   |
+| timestamp     | a Timestanp of the event, in milliseconds                                                                         |
+| participantId | The ID of the Participant that registered the `callbackUrl`                                                       |
+| deviceId      | The id of actual device exchanging media                                                                          |
+| tag           | (optional) The `tag` specified on participant creation. If no `tag` was specified this field will not be present. |
+
+## Examples
+
+### an onLeave event
+
+```json
+POST http://yourUrl.com/participantEvent
+Content-Type: application/json
+
+{
+  "event"        : "onLeave",
+  "timestamp"    : "1628786234676",
+  "participantId": "473f6544-92f7-4d67-9e77-bf2533cfff6d",
+  "deviceId"     : "be199214-1a03-402a-a7b6-d002470a0465",
+  "tag"          : "hello-world-phone"
+}
+
+```

--- a/site/docs/webrtc/webhooks.md
+++ b/site/docs/webrtc/webhooks.md
@@ -43,7 +43,7 @@ The callback URL will be invoked by Bandwidth when the above events are detected
 | Property      | Description                                                                                                       |
 | :------------ | :---------------------------------------------------------------------------------------------------------------- |
 | event         | one of `onConnect`, `onDisconnect` or `onLeave`                                                                   |
-| timestamp     | a Timestanp of the event, in milliseconds                                                                         |
+| timestamp     | a Timestamp of the event, in milliseconds                                                                         |
 | participantId | The ID of the Participant that registered the `callbackUrl`                                                       |
 | deviceId      | The id of actual device exchanging media                                                                          |
 | tag           | (optional) The `tag` specified on participant creation. If no `tag` was specified this field will not be present. |

--- a/site/sidebar.js
+++ b/site/sidebar.js
@@ -149,6 +149,7 @@ module.exports = {
             "webrtc/overview",
             "webrtc/quickstart",
             "webrtc/resources",
+            "webrtc/webhooks",
             "webrtc/voice-iw",
             "webrtc/callflow",
           ],
@@ -185,7 +186,7 @@ module.exports = {
             "emergency/dash/errors",
           ],
         },
-        "emergency/emergencyCallingApi"
+        "emergency/emergencyCallingApi",
       ],
     },
   ],


### PR DESCRIPTION
addition of a page in the new doc-site to cover the callbacks for POST .../participants, to ensure that the events were articulated, and that the beta status was documented.