### PR TITLE
MV-5742 change delete media response code to 204

### DIFF
--- a/site/specs-source/messaging.json
+++ b/site/specs-source/messaging.json
@@ -5,7 +5,7 @@
         "title": "Messaging",
         "description": "Bandwidth's HTTP Messaging platform",
         "contact": {},
-        "version": "4.2.5",
+        "version": "4.2.6",
         "x-server-configuration": {
             "default-environment": "production",
             "default-server": "default",

--- a/site/specs-source/messaging.json
+++ b/site/specs-source/messaging.json
@@ -250,7 +250,7 @@
                 },
                 "responses": {
                     "204": {
-                        "description": "",
+                        "description": "successful operation",
                         "headers": {}
                     },
                     "400": {
@@ -305,8 +305,8 @@
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "",
+                    "204": {
+                        "description": "successful operation",
                         "headers": {}
                     },
                     "400": {

--- a/site/src/pages/changelog.md
+++ b/site/src/pages/changelog.md
@@ -7,6 +7,7 @@ slug: /changelog
 
 | Date | Notes |
 |--|--|
+| October 1st, 2021 | Messaging: Updated DELETE /media HTTP response code. |
 | September 23rd, 2021 | Change `MachineDetectionRequest` schema name to `MachineDetectionConfiguration` |
 | September 21st, 2021 | Add parameters of messageDirection, carrierName and messageType to GetMessages |
 | September 15th, 2021 | Add Messaging International API Spec |


### PR DESCRIPTION
[MV-5742 Update DELETE /media in dev docs (change response code from 200 to 204)](https://bandwidth-jira.atlassian.net/browse/MV-5742)

## For the Committer

All PRs on this repo that change any API sources of truth (markdown files, OpenAPI specs) require a changelog added to the `site/src/pages/changelog.md` file. If this PR does not require changelog updates, you need to add the `no-changelog` tag to this PR before opening it.

Please confirm that you have either updated `site/src/pages/changelog.md` or added the `no-changelog` tag.
