### PR TITLE
EDGE-877 from WebRTC spec, removed unnecessary resources object

### DIFF
--- a/site/specs-source/webRtc.json
+++ b/site/specs-source/webRtc.json
@@ -1,7 +1,7 @@
 {
    "openapi": "3.0.2",
    "info": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "title": "WebRtc",
       "description": "Bandwidth WebRTC API",
       "contact": {


### PR DESCRIPTION
Removed the resources field present in the WebRTC spec; resources are not supported in OpenAPI 3.0.3 (see [here](https://swagger.io/specification/) ) and was causing an error when generating an SDK. 
