### PR TITLE
EDGE-1124 fixed small OAPI errors, changed 'example' on line 889 to an int to reflect the code type, and put '' on line 818 in its own 'items' field to avoid breaking OAPI rules

### DIFF
--- a/site/specs-source/webRtc.json
+++ b/site/specs-source/webRtc.json
@@ -1,7 +1,7 @@
 {
    "openapi": "3.0.2",
    "info": {
-      "version": "1.0.2",
+      "version": "1.0.3",
       "title": "WebRtc",
       "description": "Bandwidth WebRTC API",
       "contact": {

--- a/site/specs-source/webRtc.json
+++ b/site/specs-source/webRtc.json
@@ -814,7 +814,9 @@
                      ]
                   },
                   "readOnly": true,
-                  "$ref": "#/components/schemas/Subscriptions"
+                  "items": {
+                     "$ref": "#/components/schemas/Subscriptions"
+                  }
                },
                "tag": {
                   "type": "string",
@@ -884,7 +886,7 @@
                "code": {
                   "type": "integer",
                   "format": "int32",
-                  "example": "500"
+                  "example": 500
                },
                "message": {
                   "type": "string",


### PR DESCRIPTION
Changed the data type of error code 500 to integer so it matched the type named in the properties attribute on line 889, as well as putting the $ref into its own 'items' attribute to conform to OAPI [spec](https://swagger.io/docs/specification/using-ref/?sbsearch=no-%24ref-siblings) 'any members other than $ref in a JSON reference object are ignored'
