### PR TITLE
EDGE-1134 added clarifying language to the AddParticipanttoSession endpoint body description

### DIFF
--- a/site/specs-source/webRtc.json
+++ b/site/specs-source/webRtc.json
@@ -499,7 +499,7 @@
                }
             ],
             "requestBody": {
-               "description": "Optional set of subscriptions to set on the participant\nCalling this endpoint with no/empty body will only add the participant to the session.\nSubscriptions the participant should be created with\n\nNOTE: the request body for this endpoint is OPTIONAL and provided as a convenience to avoid calls to this and the Update Participant Subscriptions endpoint.",
+               "description": "Optional set of subscriptions to set on the participant.\nCalling this endpoint with no/empty body will only add the participant to the session.\nSubscriptions the participant should be created with\n\nNOTE: the request body for this endpoint is OPTIONAL and provided as a convenience to avoid calls to this and the Update Participant Subscriptions endpoint.",
                "required": false,
                "content": {
                   "application/json": {

--- a/site/specs-source/webRtc.json
+++ b/site/specs-source/webRtc.json
@@ -499,7 +499,7 @@
                }
             ],
             "requestBody": {
-               "description": "NOTE: the request body for this endpoint is OPTIONAL and provided as a convenience to avoid calls to multiple endpoints.\nCalling this endpoint with no/empty body will only add the designated participant to the designated session.\n\nSubscriptions the participant should be created with",
+               "description": "Optional set of subscriptions to set on the participant\nCalling this endpoint with no/empty body will only add the participant to the session.\nSubscriptions the participant should be created with\n\nNOTE: the request body for this endpoint is OPTIONAL and provided as a convenience to avoid calls to this and the Update Participant Subscriptions endpoint.",
                "required": false,
                "content": {
                   "application/json": {

--- a/site/specs-source/webRtc.json
+++ b/site/specs-source/webRtc.json
@@ -499,7 +499,7 @@
                }
             ],
             "requestBody": {
-               "description": "Optional set of subscriptions to set on the participant.\nCalling this endpoint with no/empty body will only add the participant to the session.\n\nNOTE: the request body for this endpoint is OPTIONAL and provided as a convenience to avoid calls to this and the Update Participant Subscriptions endpoint.\n\nSubscriptions the participant should be created with.",
+               "description": "Optional set of subscriptions to set on the participant.\nCalling this endpoint with no/empty body will only add the participant to the session.\n\nNOTE: the request body for this endpoint is OPTIONAL and provided as a convenience to avoid calls to this and the Update Participant Subscriptions endpoint.",
                "required": false,
                "content": {
                   "application/json": {

--- a/site/specs-source/webRtc.json
+++ b/site/specs-source/webRtc.json
@@ -499,7 +499,7 @@
                }
             ],
             "requestBody": {
-               "description": "Subscriptions the participant should be created with",
+               "description": "NOTE: the request body for this endpoint is OPTIONAL and provided as a convenience to avoid calls to multiple endpoints.\nCalling this endpoint with no/empty body will only add the designated participant to the designated session\nSubscriptions the participant should be created with",
                "required": false,
                "content": {
                   "application/json": {

--- a/site/specs-source/webRtc.json
+++ b/site/specs-source/webRtc.json
@@ -499,7 +499,7 @@
                }
             ],
             "requestBody": {
-               "description": "NOTE: the request body for this endpoint is OPTIONAL and provided as a convenience to avoid calls to multiple endpoints.\nCalling this endpoint with no/empty body will only add the designated participant to the designated session\nSubscriptions the participant should be created with",
+               "description": "NOTE: the request body for this endpoint is OPTIONAL and provided as a convenience to avoid calls to multiple endpoints.\nCalling this endpoint with no/empty body will only add the designated participant to the designated session.\n\nSubscriptions the participant should be created with",
                "required": false,
                "content": {
                   "application/json": {

--- a/site/specs-source/webRtc.json
+++ b/site/specs-source/webRtc.json
@@ -499,7 +499,7 @@
                }
             ],
             "requestBody": {
-               "description": "Optional set of subscriptions to set on the participant.\nCalling this endpoint with no/empty body will only add the participant to the session.\nSubscriptions the participant should be created with\n\nNOTE: the request body for this endpoint is OPTIONAL and provided as a convenience to avoid calls to this and the Update Participant Subscriptions endpoint.",
+               "description": "Optional set of subscriptions to set on the participant.\nCalling this endpoint with no/empty body will only add the participant to the session.\n\nNOTE: the request body for this endpoint is OPTIONAL and provided as a convenience to avoid calls to this and the Update Participant Subscriptions endpoint.\n\nSubscriptions the participant should be created with.",
                "required": false,
                "content": {
                   "application/json": {


### PR DESCRIPTION
The description for the request body of the AddParticipantToSession endpoint was not clear in the difference between it and UpdateParticipantSubscriptions, so we added some language clarifying its optional nature as well as what happens when NO body is provided with the request.
