### PR TITLE
Fix typo Paramteters

### DIFF
--- a/site/docs/messaging/webhooks.mdx
+++ b/site/docs/messaging/webhooks.mdx
@@ -34,7 +34,7 @@ When sending to Group Messages, there is a maximum of 10 participants in a Group
 **For inbound messages**, we do not limit the amount of recipients. We will pass along any messages we receive, **even if there are more than 10 recipients**.
 If you wanted to reply to all `9+{n}` recipients using V2 APIs, Bandwidth will reply with a 400 error (as you are limited to 10 recipients when sending outbound). You will need to break up the responses into separate messages to respond to more than `9+{n}` participants
 
-### Request Paramteters
+### Request Parameters
 
 | Parameter             | Type     | Description                                                                                                                                                                                                                                                                                                                                                                                       |
 |:----------------------|:---------|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
Fix typo in heading. "Request Paramteters" corrected to "Request Parameters".

## For the Committer

All PRs on this repo that change any API sources of truth (markdown files, OpenAPI specs) require a changelog added to the `site/src/pages/changelog.md` file. If this PR does not require changelog updates, you need to add the `no-changelog` tag to this PR before opening it.

Please confirm that you have either updated `site/src/pages/changelog.md` or added the `no-changelog` tag.
