### PR TITLE
Fix SIP URI format for TnOptions Failover URI

### DIFF
--- a/site/docs/numbers/managingLineFeatures.mdx
+++ b/site/docs/numbers/managingLineFeatures.mdx
@@ -677,7 +677,7 @@ HTTP 200 OK
 ### Setup Failover on a Single Number/Group of Numbers
 
 :::info
-Sip URI Format: `sip:{address}@{host}`
+Sip URI Format: `name@ip-address:port`
 
 PSTN Format: `3332221111`
 :::


### PR DESCRIPTION
## For the Committer

All PRs on this repo that change any API sources of truth (markdown files, OpenAPI specs) require a changelog added to the `site/src/pages/changelog.md` file. If this PR does not require changelog updates, you need to add the `no-changelog` tag to this PR before opening it.

Please confirm that you have either updated `site/src/pages/changelog.md` or added the `no-changelog` tag.
