### PR TITLE
Edge 1236

### DIFF
--- a/site/specs-source/webRtc.json
+++ b/site/specs-source/webRtc.json
@@ -46,10 +46,6 @@
       {
          "url": "https://api.webrtc.bandwidth.com/v1",
          "description": "Production WebRTC APIs"
-      },
-      {
-         "url": "https://rtc-api.edge.bandwidth.com/v1",
-         "description": "Staging WebRTC APIs"
       }
    ],
    "paths": {

--- a/site/src/pages/changelog.md
+++ b/site/src/pages/changelog.md
@@ -7,6 +7,7 @@ slug: /changelog
 
 | Date | Notes |
 |--|--|
+|February 2, 2022 | Removed the Staging environment from the server list for WebRTC API Specs |
 | January 31, 2022 | Added back MFA Webhooks (Callbacks) documentation
 | January 18, 2022 | Added downloadable CSV sample on Messaging Campaign UI and Import Campaign UI guides for Bulk TN Upload |
 | December 28, 2021 | Many updates to Voice API spec |


### PR DESCRIPTION
Remove the server link to the staging environment from the public API documentation for WebRTC
