### PR TITLE
Task/numbers - apidocs - csrs, disconnects

### DIFF
--- a/site/docs/numbers/disconnectNumbers.mdx
+++ b/site/docs/numbers/disconnectNumbers.mdx
@@ -2,7 +2,7 @@
 id: disconnectNumbers
 title: Disconnecting Numbers
 slug: /numbers/guides/disconnectNumbers
-description: How to order available numbers using the Bandwidth API
+description: How to disconnect numbers from account using the Bandwidth API
 keywords:
   - bandwidth
   - numbers

--- a/site/specs/numbers.json
+++ b/site/specs/numbers.json
@@ -2651,8 +2651,9 @@
         "tags": [
           "/accounts"
         ],
-        "description": "<p>Retrieves the csr orders for the given account ID.<br></p>\n",
-        "operationId": "GET /accounts/{accountId}/csrs",
+        "description": "Retrieves the csr orders for the given account ID.",
+        "summary": "List CSR orders",
+        "operationId": "ListCsrs",
         "parameters": [
           {
             "name": "accountId",
@@ -2660,63 +2661,57 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "default": null
+              "type": "string"
             },
-            "example": null
+            "example": "1234567"
           },
           {
             "name": "modifiedDateFrom",
-            "description": "<p>The earliest date that the order was last modified.</p>\n",
+            "description": "The earliest date that the order was last modified.",
             "in": "query",
             "required": false,
             "schema": {
-              "type": "date",
-              "default": null
+              "type": "date"
             },
             "example": "2014-08-05 00:00:00+00:00"
           },
           {
             "name": "modifiedDateTo",
-            "description": "<p>The latest date that the order was last modified. If no modifiedDateTo is specified when a modifiedDateFrom is specified then 'now' will be presumed to be the modifiedDateTo.</p>\n",
+            "description": "The latest date that the order was last modified. If no modifiedDateTo is specified when a modifiedDateFrom is specified then 'now' will be presumed to be the modifiedDateTo.",
             "in": "query",
             "required": false,
             "schema": {
-              "type": "date",
-              "default": null
+              "type": "date"
             },
             "example": "2014-08-05 00:00:00+00:00"
           },
           {
             "name": "page",
-            "description": "<p>The CSR order id corresponding to the page that you want to start from. \"1\" is used as a convention for the first CSR order for the account. Defaults to 1, if not provided.</p>\n",
+            "description": "The CSR order id corresponding to the page that you want to start from. \"1\" is used as a convention for the first CSR order for the account. Defaults to 1, if not provided.",
             "in": "query",
             "required": false,
             "schema": {
-              "type": "string",
-              "default": null
+              "type": "string"
             },
             "example": "ca8065d1-ec1a-43da-af40-1dcee43becb5"
           },
           {
             "name": "size",
-            "description": "<p>The maximum number of results to retrieve. Defaults to 300, if not provided.</p>\n",
+            "description": "The maximum number of results to retrieve. Defaults to 300, if not provided.",
             "in": "query",
             "required": false,
             "schema": {
-              "type": "integer",
-              "default": null
+              "type": "integer"
             },
             "example": 30
           },
           {
             "name": "status",
-            "description": "<p>Displays the CSR orders with a given order status.</p>\n",
+            "description": "Displays the CSR orders with a given order status.",
             "in": "query",
             "required": false,
             "schema": {
-              "type": "string",
-              "default": null
+              "type": "string"
             },
             "example": "complete"
           }
@@ -2724,7 +2719,7 @@
         "requestBody": {},
         "responses": {
           "200": {
-            "description": "<p>The response will include all CSR related data.</p>\n",
+            "description": "The response will include all CSR related data.",
             "content": {
               "application/xml": {
                 "examples": {

--- a/site/specs/numbers.json
+++ b/site/specs/numbers.json
@@ -3276,10 +3276,10 @@
         },
         "responses": {
           "200": {
-            "description": "OK - note has been updated.  No body is returned\n"
+            "description": "OK - note has been updated.  No body is returned"
           },
           "400": {
-            "description": "Bad Request - the note has not been updated because the payload is incomplete or in error.  An error payload is provided in the response.\n",
+            "description": "Bad Request - the note has not been updated because the payload is incomplete or in error.  An error payload is provided in the response.n",
             "content": {
               "application/xml": {
                 "examples": {

--- a/site/specs/numbers.json
+++ b/site/specs/numbers.json
@@ -3279,7 +3279,7 @@
             "description": "OK - note has been updated.  No body is returned"
           },
           "400": {
-            "description": "Bad Request - the note has not been updated because the payload is incomplete or in error.  An error payload is provided in the response.n",
+            "description": "Bad Request - the note has not been updated because the payload is incomplete or in error.  An error payload is provided in the response.",
             "content": {
               "application/xml": {
                 "examples": {

--- a/site/specs/numbers.json
+++ b/site/specs/numbers.json
@@ -2651,9 +2651,9 @@
         "tags": [
           "/accounts"
         ],
-        "description": "Retrieves the csr orders for the given account ID.",
+        "description": "Retrieves the csr orders for the given account ID.\nPlease visit <a href='/docs/numbers/guides/csrLookupTool'>Guides and Tutorials</a>",
         "summary": "List CSR orders",
-        "operationId": "ListCsrs",
+        "operationId": "ReadCsrOrders",
         "parameters": [
           {
             "name": "accountId",
@@ -2881,8 +2881,9 @@
         "tags": [
           "/accounts"
         ],
-        "description": "<p>retrieve a list of disconnect orders that is associated with an account</p>\n",
-        "operationId": "GET /accounts/{accountId}/disconnects",
+        "description": "Retrieve a list of disconnect orders that is associated with an account.\nPlease visit <a href='/docs/numbers/guides/disconnectNumbers'>Guides and Tutorials</a>",
+        "summary": "Read disconnect orders",
+        "operationId": "ReadDisconnectOrders",
         "parameters": [
           {
             "name": "accountId",
@@ -2890,14 +2891,13 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "default": null
+              "type": "string"
             },
-            "example": null
+            "example": "1234567"
           },
           {
             "name": "page",
-            "description": "<p>The disconnect order-id of the first record on the page.   \"1\" is used as a convention for the first disconnect order in the collection</p>\n",
+            "description": "The disconnect order-id of the first record on the page.   \"1\" is used as a convention for the first disconnect order in the collection",
             "in": "query",
             "required": true,
             "schema": {
@@ -2908,7 +2908,7 @@
           },
           {
             "name": "size",
-            "description": "<p>The number of records that should be returned by the query</p>\n",
+            "description": "The number of records that should be returned by the query",
             "in": "query",
             "required": true,
             "schema": {
@@ -2919,7 +2919,7 @@
           },
           {
             "name": "userid",
-            "description": "<p>The user ID associated with disconnected phone numbers</p>\n",
+            "description": "The user ID associated with disconnected phone numbers",
             "in": "query",
             "required": false,
             "schema": {
@@ -2930,7 +2930,7 @@
           },
           {
             "name": "status",
-            "description": "<p>The status of the order</p>\n",
+            "description": "The status of the order",
             "in": "query",
             "required": false,
             "schema": {
@@ -2941,7 +2941,7 @@
           },
           {
             "name": "startdate",
-            "description": "<p>Retrieves all phone numbers disconnected after this date. The start date also requires the end date to be specified.</p>\n",
+            "description": "Retrieves all phone numbers disconnected after this date. The start date also requires the end date to be specified.",
             "in": "query",
             "required": false,
             "schema": {
@@ -2952,7 +2952,7 @@
           },
           {
             "name": "enddate",
-            "description": "<p>Retrieves all phone numbers disconnected before this date. The end date also requires the start date to be specified.</p>\n",
+            "description": "Retrieves all phone numbers disconnected before this date. The end date also requires the start date to be specified.",
             "in": "query",
             "required": false,
             "schema": {
@@ -2965,7 +2965,7 @@
         "requestBody": {},
         "responses": {
           "200": {
-            "description": "<p>A list of Disconnect orders</p>\n",
+            "description": "A list of Disconnect orders",
             "content": {
               "application/xml": {
                 "examples": {
@@ -2978,7 +2978,7 @@
             }
           },
           "404": {
-            "description": "<p>No disconnect orders are present on the indicated account</p>\n",
+            "description": "No disconnect orders are present on the indicated account",
             "content": {
               "application/xml": {
                 "examples": {
@@ -2993,11 +2993,12 @@
         }
       },
       "post": {
+        "description" : "Use this method to disconnect telephone numbers from the account. Please visit <a href='/docs/numbers/guides/disconnectNumbers'>Guides and Tutorials</a>",
         "tags": [
           "/accounts"
         ],
-        "description": "<p>Create a Disconnect order, and disconnect the numbers listed in the disconnect order.</p>\n",
-        "operationId": "POST /accounts/{accountId}/disconnects",
+        "summary": "Disconnect numbers from account",
+        "operationId": "CreateDisconnectOrder",
         "parameters": [
           {
             "name": "accountId",
@@ -3005,10 +3006,9 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "default": null
+              "type": "string"
             },
-            "example": null
+            "example": "1234567"
           }
         ],
         "requestBody": {
@@ -3025,7 +3025,7 @@
         },
         "responses": {
           "201": {
-            "description": "<p>The order has been created as described in the payload <br>\nThe Location header contains the url of the disconnect order that has been created.</p>\n",
+            "description": "The order has been created as described in the payload <br>\nThe Location header contains the url of the disconnect order that has been created.",
             "content": {
               "application/xml": {
                 "examples": {
@@ -3038,7 +3038,7 @@
             }
           },
           "400": {
-            "description": "<p>Bad Response - there were errors in evaluating the body of the request.\nPotential errors include: <ul>\n  <li> Protected attribute is invalid. Valid values: TRUE, FALSE, UNCHANGED.</li>\n</ul></p>\n",
+            "description": "Bad Response - there were errors in evaluating the body of the request.\nPotential errors include: <ul>\n  <li> Protected attribute is invalid. Valid values: TRUE, FALSE, UNCHANGED.</li>\n</ul>",
             "content": {
               "application/xml": {
                 "examples": {
@@ -3058,8 +3058,9 @@
         "tags": [
           "/accounts"
         ],
-        "description": "<p>Retrieves the information associated with the disconnect order specified.</p>\n",
-        "operationId": "GET /accounts/{accountId}/disconnects/{disconnectid}",
+        "description": "Retrieves the information associated with the disconnect order specified.\nPlease visit <a href='/docs/numbers/guides/disconnectNumbers#get-disconnect-info'>Guides and Tutorials</a>",
+        "operationId": "ReadDisconnectOrder",
+        "summary": "Fetching Disconnect Order Status",
         "parameters": [
           {
             "name": "accountId",
@@ -3067,10 +3068,9 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "default": null
+              "type": "string"
             },
-            "example": null
+            "example": "1234567"
           },
           {
             "name": "disconnectid",
@@ -3078,27 +3078,26 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "default": null
+              "type": "string"
             },
-            "example": null
+            "example": "59e69657-44d2-4e7e-90f8-777988be4aef"
           },
           {
             "name": "tndetail",
-            "description": "<p>If set to true, displays the disconnect order's telephone order information in greater detail</p>\n",
+            "description": "If set to true, displays the disconnect order's telephone order information in greater detail",
             "in": "query",
             "required": false,
             "schema": {
               "type": "string",
               "default": "False"
             },
-            "example": null
+            "example": "true/false"
           }
         ],
         "requestBody": {},
         "responses": {
           "200": {
-            "description": "<p>The disconnect order's information has been successfully retrieved.</p>\n",
+            "description": "The disconnect order's information has been successfully retrieved.",
             "content": {
               "application/xml": {
                 "examples": {
@@ -3118,8 +3117,9 @@
         "tags": [
           "/accounts"
         ],
-        "description": "<p>Retrieve all notes associated with the order. <br></p>\n",
-        "operationId": "GET /accounts/{accountId}/disconnects/{disconnectid}/notes",
+        "description": "Retrieve all notes associated with the disconnect order. Please visit <a href='/docs/numbers/guides/disconnectNumbers'>Guides and Tutorials</a>",
+        "operationId": "ReadDisconnectOrderNotes",
+        "summary": "List disconnect order notes",
         "parameters": [
           {
             "name": "accountId",
@@ -3127,10 +3127,9 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "default": null
+              "type": "string"
             },
-            "example": null
+            "example": "1234567"
           },
           {
             "name": "disconnectid",
@@ -3138,16 +3137,15 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "default": null
+              "type": "string"
             },
-            "example": null
+            "example": "59e69657-44d2-4e7e-90f8-777988be4aef"
           }
         ],
         "requestBody": {},
         "responses": {
           "200": {
-            "description": "<p>OK - there are Notes associated with the order, and they have been returned in the response.</p>\n",
+            "description": "OK - there are Notes associated with the order, and they have been returned in the response.",
             "content": {
               "application/xml": {
                 "examples": {
@@ -3160,7 +3158,7 @@
             }
           },
           "204": {
-            "description": "<p>No Content - there are no Notes associated with the order.  Since the notes resource is an aggregate rather than addressed resource the generic no content response is used, rather than a 404 as would be used if the resource was addressed with an identifier</p>\n"
+            "description": "No Content - there are no Notes associated with the order.  Since the notes resource is an aggregate rather than addressed resource the generic no content response is used, rather than a 404 as would be used if the resource was addressed with an identifier"
           }
         }
       },
@@ -3168,8 +3166,9 @@
         "tags": [
           "/accounts"
         ],
-        "description": "<p>Updates the Notes resource by adding a note. Adding a note to a port-in\norder causes a notification to be sent to Bandwidth Operations, so that they may\nassist as necessary. A note may be up to 500 characters in length.</p>\n",
-        "operationId": "POST /accounts/{accountId}/disconnects/{disconnectid}/notes",
+        "description": "Updates the Notes resource by adding a note. Adding a note to a disconnect \n order causes a notification to be sent to Bandwidth Operations, so that they may\nassist as necessary. A note may be up to 500 characters in length. Please visit <a href='/docs/numbers/guides/disconnectNumbers'>Guides and Tutorials</a>",
+        "operationId": "CreateDisconnectOrderNote",
+        "summary": "Add disconnect order note",
         "parameters": [
           {
             "name": "accountId",
@@ -3177,10 +3176,9 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "default": null
+              "type": "string"
             },
-            "example": null
+            "example": "1234567"
           },
           {
             "name": "disconnectid",
@@ -3188,10 +3186,9 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "default": null
+              "type": "string"
             },
-            "example": null
+            "example": "59e69657-44d2-4e7e-90f8-777988be4aef"
           }
         ],
         "requestBody": {
@@ -3208,10 +3205,10 @@
         },
         "responses": {
           "201": {
-            "description": "<p>CREATED - the note has been created and added to the collection of notes associated with the order.  A link to the note is included in the Location header of the response.  No body is returned</p>\n"
+            "description": "CREATED - the note has been created and added to the collection of notes associated with the order.  A link to the note is included in the Location header of the response.  No body is returned"
           },
           "400": {
-            "description": "<p>Bad Request - the note has not been created because the payload is incomplete or in error.  An error payload is provided in the response.</p>\n",
+            "description": "Bad Request - the note has not been created because the payload is incomplete or in error.  An error payload is provided in the response.",
             "content": {
               "application/xml": {
                 "examples": {
@@ -3231,8 +3228,9 @@
         "tags": [
           "/accounts"
         ],
-        "description": "<p>Update a specified note.  Notes may only be updated, not deleted.</p>\n",
-        "operationId": "PUT /accounts/{accountId}/disconnects/{disconnectid}/notes/{noteId}",
+        "description": "Update a specified note.  Notes may only be updated, not deleted. Please visit <a href='/docs/numbers/guides/disconnectNumbers'>Guides and Tutorials</a>\n",
+        "operationId": "UpdateDisconnectOrderNote",
+        "summary": "Update disconnect order note",
         "parameters": [
           {
             "name": "accountId",
@@ -3240,10 +3238,9 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "default": null
+              "type": "string"
             },
-            "example": null
+            "example": "1234567"
           },
           {
             "name": "disconnectid",
@@ -3251,10 +3248,9 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "default": null
+              "type": "string"
             },
-            "example": null
+            "example": "59e69657-44d2-4e7e-90f8-777988be4aef"
           },
           {
             "name": "noteId",
@@ -3262,10 +3258,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "default": null
-            },
-            "example": null
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
@@ -3282,10 +3276,10 @@
         },
         "responses": {
           "200": {
-            "description": "<p>OK - note has been updated.  No body is returned</p>\n"
+            "description": "OK - note has been updated.  No body is returned\n"
           },
           "400": {
-            "description": "<p>Bad Request - the note has not been updated because the payload is incomplete or in error.  An error payload is provided in the response.</p>\n",
+            "description": "Bad Request - the note has not been updated because the payload is incomplete or in error.  An error payload is provided in the response.\n",
             "content": {
               "application/xml": {
                 "examples": {


### PR DESCRIPTION
First PR related to the task.

BTW I did not find any other api docs related to csrs even in iris.min.yaml - which means we didn't have docs for some csrs resources, correct? 

Made changes for few endpoints:
/accounts/{accountId}/csrs 
/accounts/{accountId}/disconnects 
/accounts/{accountId}/disconnects/{disconnectid} 
/accounts/{accountId}/disconnects/{disconnectid}/notes 
/accounts/{accountId}/disconnects/{disconnectid}/notes/{noteId}

![Screenshot 2022-03-22 at 18 47 00](https://user-images.githubusercontent.com/5918477/159531952-75a3c772-95b8-4613-8bf2-ee76567c8cc6.png)
![Screenshot 2022-03-22 at 18 47 31](https://user-images.githubusercontent.com/5918477/159532046-354be923-c126-42ef-b85d-fe637e29c2d0.png)

The summary of changes here:
* Add operationalIds
* Reference 'Guides and Tutorials' in description
* Change summary to friendly
* Remove html tags
* Remove default=null from all required fields (my personal feeling)