### PR TITLE
Fix Broken Guide Link

### DIFF
--- a/site/docs/account/dashboard-setup.mdx
+++ b/site/docs/account/dashboard-setup.mdx
@@ -244,7 +244,7 @@ Now that your Account is set up, you’re ready to order a phone number and begi
 
 For a guide on ordering phone numbers in the Bandwidth Dashboard, [click here](https://support.bandwidth.com/hc/en-us/articles/360011094753-How-do-I-search-and-order-phone-numbers-)!
 
-For a guide on ordering phone numbers via the Bandwidth Dashboard API, [click here](../numbers/guides/orderingNumbers)!
+For a guide on ordering phone numbers via the Bandwidth Dashboard API, [click here](/docs/numbers/guides/orderingNumbers)!
 
 ## Next steps
 ### Create an API-only User


### PR DESCRIPTION
the relative URL is broken here due to the `/#...` added to the URL by either docusaurus or aws