### PR TITLE
Note mentioning delay in order state from History API

### DIFF
--- a/site/specs/numbers.json
+++ b/site/specs/numbers.json
@@ -9226,7 +9226,7 @@
         "tags": [
           "/accounts"
         ],
-        "description": "Retrieves the history of the specified port-in order. Obtaining history for a draft port-in is not supported.",
+        "description": "Retrieves the history of the specified port-in order. Obtaining history for a draft port-in is not supported.<br>Note: The order history may be updated several seconds after an operation that should cause a history record update. As a consequence, this endpoint should never be used to fetch the current order status. To fetch the current order status, please use GET /accounts/{accountId}/portins/{orderId}.",
         "operationId": "RetrievePortinHistory",
         "summary": "Retrieve port-in order history",
         "parameters": [


### PR DESCRIPTION
Added a note to History endpoint indicating the delay in retrieving updated the status of port-in