### PR TITLE
Fix conference created event type in example.

### DIFF
--- a/site/docs/voice/webhooks/conferenceCreated.mdx
+++ b/site/docs/voice/webhooks/conferenceCreated.mdx
@@ -80,7 +80,7 @@ Content-Type: application/json
 {
     "conferenceId"   : "conf-59082d52-4a2ab5be-ce26-43ed-af94-431b8a19d4e3",
     "name"           : "thisConference",
-    "eventType"      : "conferenceCompleted",
+    "eventType"      : "conferenceCreated",
     "eventTime"      : "2019-07-31T13:16:01.324Z",
     "tag"            : "conferenceTag"
 }


### PR DESCRIPTION
**⚠️Please do not make any changes to spec files in this repository!⚠️**

**All spec changes should be done in the [api-specs](https://github.com/Bandwidth/api-specs) repository.**

**Please follow the [Guide](https://bandwidth-jira.atlassian.net/wiki/spaces/DX/pages/4098359409/How+to+Update+API+Specifications+and+Contribute+to+Developer+Documentation) for contributing to our developer documentation.**

Edited the "eventType" field in example response to match the appropriate type for conferenceCreated.
