### PR TITLE
response schema's for sites/{id}/inserviceNumbers|orders|orders/{id}|…

### DIFF
--- a/site/specs-temp/numbers.json
+++ b/site/specs-temp/numbers.json
@@ -16263,6 +16263,9 @@
                   "example": {
                     "value": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<TNs>\n   <TotalCount>54</TotalCount>\n   <Links>\n      <first>\n         <!-- SNIP -->\n      </first>\n      <next>\n         <!-- SNIP -->\n      </next>\n   </Links>\n   <TelephoneNumbers>\n      <Count>3</Count>\n      <TelephoneNumber>4352154855</TelephoneNumber>\n      <!-- SNIP -->\n      <TelephoneNumber>4352161523</TelephoneNumber>\n   </TelephoneNumbers>\n</TNs>"
                   }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/AccountTelephoneNumbersHistoryResponse"
                 }
               }
             }
@@ -16329,6 +16332,9 @@
                   "example": {
                     "value": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<ResponseSelectWrapper>\n   <ListOrderIdUserIdDate>\n      <TotalCount>47</TotalCount>\n      <Links>\n         <first>Link=&lt;https://dashboard.bandwidth.com/api/accounts/12346099/sites/743/orders?page=1&amp;size=30&gt;;rel=\"first\";</first>\n         <next>Link=&lt;https://dashboard.bandwidth.com/api/accounts/12346099/sites/743/orders?page=fa7bc01a-cb4d-4eae-9621-560020f45105&amp;size=30&gt;;rel=\"next\";</next>\n      </Links>\n      <OrderIdUserIdDate>\n         <CountOfTNs>1</CountOfTNs>\n         <userId>jbm</userId>\n         <lastModifiedDate>2014-01-06T19:09:44.027Z</lastModifiedDate>\n         <OrderType>new_number</OrderType>\n         <OrderDate>2014-01-06T19:09:43.695Z</OrderDate>\n         <orderId>13c97416-9eee-4da3-aff8-ba85d1297ef2</orderId>\n         <OrderStatus>COMPLETE</OrderStatus>\n         <TelephoneNumberDetails>\n            <States>\n               <StateWithCount>\n                  <State>VA</State>\n                  <Count>1</Count>\n               </StateWithCount>\n            </States>\n            <RateCenters>\n               <RateCenterWithCount>\n                  <Count>1</Count>\n                  <RateCenter>GLOUCESTER</RateCenter>\n               </RateCenterWithCount>\n            </RateCenters>\n            <Cities>\n               <CityWithCount>\n                  <City>GLOUCESTER</City>\n                  <Count>1</Count>\n               </CityWithCount>\n            </Cities>\n            <Tiers>\n               <TierWithCount>\n                  <Tier>0</Tier>\n                  <Count>1</Count>\n               </TierWithCount>\n            </Tiers>\n            <Vendors>\n               <VendorWithCount>\n                  <VendorId>49</VendorId>\n                  <VendorName>Bandwidth CLEC</VendorName>\n                  <Count>1</Count>\n               </VendorWithCount>\n            </Vendors>\n         </TelephoneNumberDetails>\n      </OrderIdUserIdDate>\n   </ListOrderIdUserIdDate>\n</ResponseSelectWrapper>"
                   }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SiteOrdersResponse"
                 }
               }
             }
@@ -16397,6 +16403,9 @@
                   "example": {
                     "value": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<OrderResponse>\n   <CompletedQuantity>1</CompletedQuantity>\n   <CreatedByUser>jbm</CreatedByUser>\n   <LastModifiedDate>2014-01-06T19:09:44.027Z</LastModifiedDate>\n   <OrderCompleteDate>2014-01-06T19:09:44.041Z</OrderCompleteDate>\n   <Order>\n      <CustomerOrderId>123456789</CustomerOrderId>\n      <Name>Area Code Order</Name>\n      <OrderCreateDate>2014-01-06T19:09:43.695Z</OrderCreateDate>\n      <PeerId>303716</PeerId>\n      <siteId>743</siteId>\n      <BackOrderRequested>false</BackOrderRequested>\n      <AreaCodeSearchAndOrderType>\n         <AreaCode>804</AreaCode>\n         <Quantity>1</Quantity>\n      </AreaCodeSearchAndOrderType>\n      <PartialAllowed>true</PartialAllowed>\n      <SiteId>743</SiteId>\n   </Order>\n   <OrderStatus>COMPLETE</OrderStatus>\n   <CompletedNumbers>\n      <TelephoneNumber>\n         <FullNumber>8042105666</FullNumber>\n      </TelephoneNumber>\n   </CompletedNumbers>\n   <FailedQuantity>0</FailedQuantity>\n</OrderResponse>"
                   }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/TnOrderUpdatedResponse"
                 }
               }
             }
@@ -16453,6 +16462,9 @@
                   "example": {
                     "value": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<TelephoneNumbers>\n   <Count>1</Count>\n   <TelephoneNumber>8042105666</TelephoneNumber>\n</TelephoneNumbers>"
                   }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/OrderTelephoneNumbersResponse"
                 }
               }
             }
@@ -16531,6 +16543,9 @@
                   "example": {
                     "value": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<LNPResponseWrapper>\n   <TotalCount>7</TotalCount>\n   <Links>\n      <first>\n         <!-- SNIP -->\n      </first>\n      <next>\n         <!-- SNIP -->\n      </next>\n   </Links>\n   <lnpPortInfoForGivenStatus>\n      <CountOfTNs>1</CountOfTNs>\n      <userId>jbm</userId>\n      <OrderId>ca8065d1-ec1a-43da-af40-1dcee43becb5</OrderId>\n      <OrderType>port_in</OrderType>\n      <BillingTelephoneNumber>9192803466</BillingTelephoneNumber>\n      <lastModifiedDate>2014-05-20T14:43:19.222Z</lastModifiedDate>\n      <LNPLosingCarrierId>1537</LNPLosingCarrierId>\n      <LNPLosingCarrierName>Mock Carrier</LNPLosingCarrierName>\n      <OrderDate>2014-05-20T14:43:32.828Z</OrderDate>\n      <ProcessingStatus>CANCELLED</ProcessingStatus>\n      <RequestedFOCDate>2015-05-15T20:00:00.000Z</RequestedFOCDate>\n      <VendorId>49</VendorId>\n      <VendorName>Bandwidth CLEC</VendorName>\n   </lnpPortInfoForGivenStatus>\n</LNPResponseWrapper>"
                   }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/LNPResponseWrapper"
                 }
               }
             }
@@ -16577,6 +16592,9 @@
                   "example": {
                     "value": "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<SiteTNsResponse>\n   <SiteTNs>\n      <TotalCount>26</TotalCount>\n   </SiteTNs>\n</SiteTNsResponse>"
                   }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/SiteTNsResponse"
                 }
               }
             }
@@ -28408,6 +28426,43 @@
             "type": "object",
             "properties": {
               "Count": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "SiteOrdersResponse": {
+        "type": "object",
+        "properties": {
+          "ResponseSelectWrapper": {
+            "type": "object",
+            "properties": {
+              "ListOrderIdUserIdDate": {
+                "type": "object",
+                "properties": {
+                  "TotalCount": {
+                    "type": "integer"
+                  },
+                  "OrderIdUserIdDate": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/OrderSummary"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "SiteTNsResponse": {
+        "type": "object",
+        "properties": {
+          "SiteTNs": {
+            "type": "object",
+            "properties": {
+              "TotalCount": {
                 "type": "integer"
               }
             }


### PR DESCRIPTION
…totalTns|portins

<img width="357" alt="Снимок экрана 2022-06-19 в 14 02 44" src="https://user-images.githubusercontent.com/30110721/174477773-a0a1cbaf-72df-44a5-b82c-72edb80188c6.png">

