### PR TITLE
changing the Url for sample apps for MFA

### DIFF
--- a/site/docs/mfa/about.mdx
+++ b/site/docs/mfa/about.mdx
@@ -50,7 +50,7 @@ To create an MFA event, simply send a <Highlight color="#079CEE">POST</Highlight
 
 | Links | Description |
 | :---- | :---- |
-| [MFA Sample Applications](https://github.com/search?q=topic%3Amfa+org%3ABandwidth-Samples) | MFA sample applications for a variety of technologies |
+| [MFA Sample Applications](https://github.com/search?q=org%3ABandwidth-Samples+mfa) | MFA sample applications for a variety of technologies |
 
 ## Blogs
 


### PR DESCRIPTION
The current link is 'https://github.com/search?q=topic%3Amfa+org%3ABandwidth-Samples '
and needs to be 'https://github.com/search?q=org%3ABandwidth-Samples+mfa '

Awaiting the auto-build to verify that it works before I change to real PR
