### PR TITLE
api_reference - moved re-usable parameters under components/parameter…

### DIFF
--- a/site/specs-temp/numbers.json
+++ b/site/specs-temp/numbers.json
@@ -1610,7 +1610,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "date"
+              "type": "string"
             },
             "example": "2021-06-21T18:45:00.000Z"
           },
@@ -1620,7 +1620,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "date"
+              "type": "string"
             },
             "example": "2021-06-21T18:45:00.000Z"
           },
@@ -1630,7 +1630,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "date"
+              "type": "string"
             },
             "example": "2021-06-21T18:45:00.000Z"
           },
@@ -3045,7 +3045,7 @@
         ],
         "description": "Update csr order",
         "summary": "Update CSR order",
-        "operationId": "CreateCsrOrder",
+        "operationId": "UpdateCsrOrder",
         "parameters": [
           {
             "name": "accountId",
@@ -5341,7 +5341,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "date",
+              "type": "string",
               "format": "date-time"
             },
             "example": "2020-03-15T14:00:00.000-04:00"
@@ -5430,7 +5430,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "date",
+              "type": "string",
               "default": "now",
               "format": "date-time"
             },
@@ -5757,7 +5757,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "date",
+              "type": "string",
               "default": "now",
               "format": "date-time"
             },
@@ -5958,7 +5958,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "date",
+              "type": "string",
               "format": "date-time"
             },
             "example": "2020-03-30T14:00:00Z"
@@ -6047,7 +6047,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "date",
+              "type": "string",
               "default": "now",
               "format": "date-time"
             },
@@ -7603,10 +7603,10 @@
         "operationId": "ReadImportVoiceTnOrders",
         "parameters": [
           {
-            "$ref": "#/components/schemas/AccountIdPathParam"
+            "$ref": "#/components/parameters/AccountIdPathParam"
           },
           {
-            "$ref": "#/components/schemas/StatusQueryParam"
+            "$ref": "#/components/parameters/StatusQueryParam"
           },
           {
             "name": "tn",
@@ -7706,7 +7706,7 @@
         "operationId": "CreateVoiceImportTnOrder",
         "parameters": [
           {
-            "$ref": "#/components/schemas/AccountIdPathParam"
+            "$ref": "#/components/parameters/AccountIdPathParam"
           }
         ],
         "requestBody": {
@@ -7767,10 +7767,10 @@
         "operationId": "ReadImportVoiceTnOrder",
         "parameters": [
           {
-            "$ref": "#/components/schemas/AccountIdPathParam"
+            "$ref": "#/components/parameters/AccountIdPathParam"
           },
           {
-            "$ref": "#/components/schemas/OrderIdPathParam"
+            "$ref": "#/components/parameters/OrderIdPathParam"
           }
         ],
         "responses": {
@@ -7802,10 +7802,10 @@
         "operationId": "ReadImportVoiceTnOrderHistory",
         "parameters": [
           {
-            "$ref": "#/components/schemas/AccountIdPathParam"
+            "$ref": "#/components/parameters/AccountIdPathParam"
           },
           {
-            "$ref": "#/components/schemas/OrderIdPathParam"
+            "$ref": "#/components/parameters/OrderIdPathParam"
           }
         ],
         "responses": {
@@ -11961,7 +11961,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "date"
+              "type": "string"
             },
             "example": "2014-08-01"
           },
@@ -11971,7 +11971,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "date"
+              "type": "string"
             },
             "example": "2014-08-05"
           },
@@ -11981,7 +11981,7 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "date"
+              "type": "string"
             },
             "example": "2014-08-05"
           }
@@ -12182,9 +12182,9 @@
             "example": "1234567"
           }
         ],
-        "requestBody": {},
         "responses": {
           "200": {
+            "description": "",
             "content": {
               "application/xml": {
                 "schema": {
@@ -12266,6 +12266,7 @@
         ],
         "responses": {
           "200": {
+            "description": "",
             "content": {
               "application/xml": {
                 "schema": {
@@ -13395,10 +13396,10 @@
         "operationId": "ListRemoveImportedVoiceTnOrders",
         "parameters": [
           {
-            "$ref": "#/components/schemas/AccountIdPathParam"
+            "$ref": "#/components/parameters/AccountIdPathParam"
           },
           {
-            "$ref": "#/components/schemas/StatusQueryParam"
+            "$ref": "#/components/parameters/StatusQueryParam"
           },
           {
             "name": "tn",
@@ -13488,7 +13489,7 @@
         "operationId": "CreateRemoveImportedVoiceTnOrder",
         "parameters": [
           {
-            "$ref": "#/components/schemas/AccountIdPathParam"
+            "$ref": "#/components/parameters/AccountIdPathParam"
           }
         ],
         "requestBody": {
@@ -13546,10 +13547,10 @@
         "operationId": "RetrieveRemoveImportedVoiceTnOrder",
         "parameters": [
           {
-            "$ref": "#/components/schemas/AccountIdPathParam"
+            "$ref": "#/components/parameters/AccountIdPathParam"
           },
           {
-            "$ref": "#/components/schemas/OrderIdPathParam"
+            "$ref": "#/components/parameters/OrderIdPathParam"
           }
         ],
         "responses": {
@@ -13581,10 +13582,10 @@
         "operationId": "RetrieveRemoveImportedVoiceTnOrderHistory",
         "parameters": [
           {
-            "$ref": "#/components/schemas/AccountIdPathParam"
+            "$ref": "#/components/parameters/AccountIdPathParam"
           },
           {
-            "$ref": "#/components/schemas/OrderIdPathParam"
+            "$ref": "#/components/parameters/OrderIdPathParam"
           }
         ],
         "responses": {
@@ -15065,19 +15066,55 @@
                   },
                   "VoiceHosts": {
                     "description": "These addresses, comprised of HostName and optional Port, are used by the Bandwidth network to send calls to for Origination services. The VoiceHosts list of IP addresses used for an active/standby address selection mechanism, where the first address is attempted, followed by the second address and so on. Except under failure situations the first address in the list is preferred. Maximum of 10 hosts - can be IP address or Fully Qualified Domain Name",
-                    "type": "array"
+                    "type": "array",
+                    "items": {
+                      "properties": {
+                        "Host": {
+                          "type": "object",
+                          "properties": {
+                            "HostName": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
                   },
                   "VoiceHostGroups": {
                     "description": "The VoiceHostGroups element is comprised of one VoiceHostGroup element, which is used to randomly distribute traffic amongst up to 10 IP addresses. Failover behavior is retained within the group",
-                    "type": "array"
-                  },
-                  "VoiceHostGroup": {
-                    "description": "A VoiceHostGroup is a list of IP Addresses (the Host element). This traffic distribution model distributes traffic in a Random manner amongst the addresses in the group",
-                    "type": "array"
+                    "type": "array",
+                    "items": {
+                      "properties": {
+                        "VoiceHostGroup": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Hosts"
+                          }
+                        }
+                      }
+                    }
                   },
                   "TerminationHosts": {
                     "description": "These addresses, comprised of IP or Subnet(CIDR format) and optional Port, are used by the Bandwidth network to send calls to for Termination services. Maximum of 10 hosts - can be IP address or subnets. In case of subnet you should specify NetworkAddress of subnet as IP",
-                    "type": "array"
+                    "type": "array",
+                    "items": {
+                      "properties": {
+                        "TerminationHost": {
+                          "type": "object",
+                          "properties": {
+                            "HostName": {
+                              "type": "string"
+                            },
+                            "Port": {
+                              "type": "string"
+                            },
+                            "CustomerTrafficAllowed": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
                   },
                   "CustomerTrafficAllowed": {
                     "description": "A TerminationHost can be configured to allow different customer traffic types.  Allowed values are LITE, DOMESTIC and ALL. This is an optional parameter",
@@ -21026,7 +21063,7 @@
             ]
           },
           "Sms": {
-            "$ref": "#/components/schemas/RecipientSMS"
+            "$ref": "#/components/schemas/RecipientSms"
           }
         }
       },
@@ -21162,19 +21199,19 @@
       },
       "RecipientCreatedDate": {
         "description": "Creation date of the recipient.",
-        "type": "date-time"
+        "type": "string"
       },
       "GroupCreatedDate": {
         "description": "Creation date of the group.",
-        "type": "date-time"
+        "type": "string"
       },
       "OrderCreatedDate": {
         "description": "Creation date of the order.",
-        "type": "date-time"
+        "type": "string"
       },
       "RecipientLastModifiedDate": {
         "description": "Last modified date of the recipient.",
-        "type": "date-time"
+        "type": "string"
       },
       "GroupModifiedBy": {
         "description": "Group modified by the user.",
@@ -21182,9 +21219,9 @@
       },
       "GroupModifiedDate": {
         "description": "Last modified date of the recipient.",
-        "type": "date-time"
+        "type": "string"
       },
-      "RecipientSMS": {
+      "RecipientSms": {
         "description": "A telephone number capable of receiving text messages that must be specified when Type is set to SMS.",
         "type": "object",
         "properties": {
@@ -21335,7 +21372,14 @@
             "$ref": "#/components/schemas/EepToEngAssociations"
           },
           "ErrorList": {
-            "type": "list"
+            "type": "array",
+            "items": {
+              "properties": {
+                "Description": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       },
@@ -25620,11 +25664,9 @@
             "type": "string"
           },
           "WorkingTelephoneNumbersOnAccount": {
-            "type": "object",
-            "properties": {
-              "TelephoneNumber": {
-                "type": "array"
-              }
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TelephoneNumber"
             }
           },
           "CsrServiceAddress": {
@@ -25690,11 +25732,9 @@
             "type": "string"
           },
           "WorkingTelephoneNumbersOnAccount": {
-            "type": "object",
-            "properties": {
-              "TelephoneNumber": {
-                "type": "array"
-              }
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TelephoneNumber"
             }
           },
           "CsrServiceAddress": {
@@ -29216,8 +29256,15 @@
             "description": "Calling Name of the caller is available to the user or not on incoming calls"
           },
           "TnAttributes": {
+            "description": "Is this telephone number protected or not",
             "type": "array",
-            "description": "Is this telephone number protected or not"
+            "items": {
+              "properties": {
+                "TnAttribute": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "MessagingSettings": {
             "type": "string",
@@ -31605,6 +31652,144 @@
           }
         }
       },
+      "SippeerRequest": {
+        "type": "object",
+        "properties": {
+          "PeerName": {
+            "description": "Mandatory name for the SIP Peer",
+            "maxLength": 10,
+            "type": "string"
+          },
+          "Description": {
+            "description": "Description for the SIP Peer",
+            "type": "string"
+          },
+          "IsDefaultPeer": {
+            "description": "Value is True or False. The Default SIP Peer is the default \"destination\" for any Telephone Numbers that are ordered for the Site in which the SIP Peer resides.  Each Site can have only 1 default SIP Peer. You can configure multiple SIP Peers on a Site",
+            "type": "boolean"
+          },
+          "HostName": {
+            "description": "The IP Address or Host Name of the address to be used for the VoiceHosts or VoiceHostGroups addresses",
+            "type": "string"
+          },
+          "Port": {
+            "description": "Optional Port Number for Voice and Termination hosts. This is an optional parameter that has default values that are dependent on the Application",
+            "type": "integer"
+          },
+          "VoiceHosts": {
+            "description": "These addresses, comprised of HostName and optional Port, are used by the Bandwidth network to send calls to for Origination services. The VoiceHosts list of IP addresses used for an active/standby address selection mechanism, where the first address is attempted, followed by the second address and so on. Except under failure situations the first address in the list is preferred. Maximum of 10 hosts - can be IP address or Fully Qualified Domain Name",
+            "type": "array",
+            "items": {
+              "properties": {
+                "Host": {
+                  "type": "object",
+                  "properties": {
+                    "HostName": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "VoiceHostGroups": {
+            "description": "The VoiceHostGroups element is comprised of one VoiceHostGroup element, which is used to randomly distribute traffic amongst up to 10 IP addresses. Failover behavior is retained within the group",
+            "type": "array",
+            "items": {
+              "properties": {
+                "VoiceHostGroup": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Hosts"
+                  }
+                }
+              }
+            }
+          },
+          "TerminationHosts": {
+            "description": "These addresses, comprised of IP or Subnet(CIDR format) and optional Port, are used by the Bandwidth network to send calls to for Termination services. Maximum of 10 hosts - can be IP address or subnets. In case of subnet you should specify NetworkAddress of subnet as IP",
+            "type": "array",
+            "items": {
+              "properties": {
+                "TerminationHost": {
+                  "type": "object",
+                  "properties": {
+                    "HostName": {
+                      "type": "string"
+                    },
+                    "Port": {
+                      "type": "string"
+                    },
+                    "CustomerTrafficAllowed": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "Address": {
+            "description": "Billing or Service Address for the SIP Peer.  This element is optional for accounts except for accounts with the UC Trunking Product.  If the address element is provided the following fields can be provided:",
+            "type": "object",
+            "required": [
+              "HouseNumber",
+              "StreetName",
+              "City",
+              "StateCode",
+              "Zip",
+              "AddressType"
+            ],
+            "properties": {
+              "HouseNumber": {
+                "type": "string"
+              },
+              "HouseSuffix": {
+                "type": "string"
+              },
+              "PreDirectional": {
+                "type": "string"
+              },
+              "StreetName": {
+                "type": "string"
+              },
+              "StreetSuffix": {
+                "type": "string"
+              },
+              "PostDirectional": {
+                "type": "string"
+              },
+              "City": {
+                "type": "string"
+              },
+              "StateCode": {
+                "type": "string"
+              },
+              "Zip": {
+                "type": "string"
+              },
+              "PlusFour": {
+                "type": "string"
+              },
+              "County": {
+                "type": "string"
+              },
+              "Country": {
+                "type": "string",
+                "default": "US"
+              },
+              "AddressType": {
+                "type": "string",
+                "enum": [
+                  "Billing",
+                  "Service"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "parameters": {
       "AccountIdPathParam": {
         "name": "accountId",
         "description": "User's account ID",


### PR DESCRIPTION
…s(from version 3.0 cannot use parameters in schemas). Fixed errors and missed items, duplicate CreateCsrOrder, moved Create SipPeer request to components.

**⚠️Please do not make any changes to spec files in this repository!⚠️**

**All spec changes should be done in the [api-specs](https://github.com/Bandwidth/api-specs) repository.**

**Please follow the [Guide](https://bandwidth-jira.atlassian.net/wiki/spaces/DX/pages/4098359409/How+to+Update+API+Specifications+and+Contribute+to+Developer+Documentation) for contributing to our developer documentation.**
