### PR TITLE
BWDB-13907: Adding Porting tag to bulkPortins and tollFreePortingValidations endpoints

### DIFF
--- a/site/specs-temp/numbers.json
+++ b/site/specs-temp/numbers.json
@@ -1701,7 +1701,8 @@
     "/accounts/{accountId}/bulkPortins": {
       "get": {
         "tags": [
-          "/accounts"
+          "/accounts",
+          "Porting"
         ],
         "description": "Retrieves bulk port-in orders for the specified accountId.\nA maximum of 1,000 orders can be retrieved per request. If no date range or specific query parameter is provided, the order results will be limited to the last two years. Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a>",
         "operationId": "ListBulkPortins",
@@ -1818,7 +1819,8 @@
       },
       "post": {
         "tags": [
-          "/accounts"
+          "/accounts",
+          "Porting"
         ],
         "description": "<p>Creates a bulk port-in order to be used as a template for a collection of child port-in orders.  The template values will be cascaded to child port-ins that result from decomposing a collection of Telephone Numbers that span carriers, RespOrgs, or have attributes that drive the decomposition into a number of individual port-in orders.<p></p> Upon a successfully-submitted payload, the order will have a status of \"DRAFT\", denoting that further modification to the template is expected.  For example, the next step is to use the /tnList endpoint to add a collection of telephone numbers to the bulk port-in order. The only valid value for the ProcessingStatus element in a POST is 'DRAFT', which is the default value.</p><p>Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a></p>",
         "operationId": "CreateBulkOrder",
@@ -1879,7 +1881,8 @@
     "/accounts/{accountId}/bulkPortins/{orderid}": {
       "get": {
         "tags": [
-          "/accounts"
+          "/accounts",
+          "Porting"
         ],
         "description": "Retrieves information associated with the bulk port-in order specified by the orderId URI parameter. Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a>",
         "operationId": "RetrieveBulkOrder",
@@ -1922,7 +1925,8 @@
       },
       "put": {
         "tags": [
-          "/accounts"
+          "/accounts",
+          "Porting"
         ],
         "description": "The PUT operation is available only for bulk port-in orders that are not yet associated with subtending orders. Since this only occurs for bulk port-in orders that are in one of the draft states, there are few restrictions on what may be included. As with the POST, any data associated with the bulk port-in will cascade to subtending orders when they are created. (Subtending orders are created after telephone numbers are added to the bulk port-in using the /tnList endpoint.) The PUT completely replaces the existing Bulk Portin order with the payload of the PUT. Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a>.<br/><br/>The following element may appear only in PUT or PATCH operations on a bulk port-in order. <ul><li><b>RetryValidation</b> - When toll free numbers are included in a port-in order, Bandwidth accesses a vendor to determine if the numbers are portable, and if so, from which RespOrg. In the event that we do not receive a response from our vendor after a number of retries, we give up and place the order in the INVALID_DRAFT_TNS state. This scenario can occur if our toll free porting vendor is performing maintenance, for example. Including RetryValidation with a value of true will cause the order to return to VALIDATE_DRAFT_TNS and we will repeat our attempts to retrieve the portability data from the vendor. This element is included in the synchronous response to the PUT or PATCH, when included in the request, but is not included in subsequent GET requests for the order.</li></ul>",
         "operationId": "PutBulkOrder",
@@ -1990,7 +1994,8 @@
       },
       "delete": {
         "tags": [
-          "/accounts"
+          "/accounts",
+          "Porting"
         ],
         "description": "Delete a bulk port-in order with child port-ins.  Deleting a bulk port-in is allowed for 'DRAFT' state only.  Deleting a bulk port-in will delete all DRAFT child port-ins associated with the bulk port-in.  When the bulk port-in is deleted, any child port-in orders that are not in a draft status are dissociated from the bulk port-in, but not deleted. Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a>",
         "operationId": "DeleteBulkOrder",
@@ -2033,7 +2038,8 @@
       },
       "patch": {
         "tags": [
-          "/accounts"
+          "/accounts",
+          "Porting"
         ],
         "description": "<p>It is possible to change (\"SUPP\" in LNP terms) an existing Bulk Port-in order.  This is done via a PUT or PATCH on the existing order-id.  Since the Bulk Port-in\n  order acts as a template for port-in orders in DRAFT status, any record can be changed at any time.  The PATCH replaces elements of the referenced Bulk Portin order, but it replaces only the records included in the request payload.  Other elements will remain untouched.</p><p>Changing the fields in a Bulk Port-in order causes the system to reapply all changed values to the child port-ins contained in the list of subtending port-in orders. Note that if the port-in orders contained within the Bulk Port are in DRAFT state, any field can be modified. If any child port-in order in the Bulk Port-in is in any other state, normal SUPP rules apply, and the list of appropriate fields is smaller.</p><p>Changing the ProcessingStatus to 'IN_PROGRESS' causes all child port-ins to begin processing. This is only valid if child port-ins exist for the bulk port-in.</p> <p>Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a></p>",
         "operationId": "PatchBulkOrder",
@@ -2103,7 +2109,8 @@
     "/accounts/{accountId}/bulkPortins/{orderid}/portinList": {
       "get": {
         "tags": [
-          "/accounts"
+          "/accounts",
+          "Porting"
         ],
         "description": "Retrieves a list of Port-in Orders that are all associated with the identified Bulk Port-in.   This response is not paginated due to its inherently limited size. Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a>",
         "operationId": "ListBulkChildOrders",
@@ -2143,7 +2150,8 @@
       },
       "put": {
         "tags": [
-          "/accounts"
+          "/accounts",
+          "Porting"
         ],
         "description": "<p>A PUT on a PortinList resource will cause replacement of the list of port-in orders associated with the specified bulk port-in.</p><p>This PUT will completely replace the existing list of port-in orders associated with the bulk port-in.  If all port-in orders in the list are not valid, the PUT request will fail, due to the potential for losing the port-in to bulk port-in relationships.</p><p>Only port-in orders in a draft status may be associated with a bulk port-in order.  And port-in orders may only be added to a bulk port-in order while that bulk port-in order is still in a draft state.</p><p>Child port-in orders may be dissociated from the bulk port-in at any time. </p> <p>Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a></p>",
         "operationId": "UpdateBulkChildList",
@@ -2203,7 +2211,8 @@
     "/accounts/{accountId}/bulkPortins/{orderid}/notes": {
       "get": {
         "tags": [
-          "/accounts"
+          "/accounts",
+          "Porting"
         ],
         "description": "Retrieve all notes associated with the order. Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a>",
         "operationId": "ListBulkNotes",
@@ -2306,7 +2315,8 @@
     "/accounts/{accountId}/bulkPortins/{orderid}/notes/{noteId}": {
       "put": {
         "tags": [
-          "/accounts"
+          "/accounts",
+          "Porting"
         ],
         "description": "Update a specified note.  Notes may only be updated, not deleted. Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a>",
         "operationId": "UpdateBulkNote",
@@ -2376,7 +2386,8 @@
     "/accounts/{accountId}/bulkPortins/{orderid}/tnList": {
       "get": {
         "tags": [
-          "/accounts"
+          "/accounts",
+          "Porting"
         ],
         "description": "<p>The information returned in the GET /tnList response payload depends on the ProcessingStatus of the bulk port-in order. See the Responses tab for examples of each response payload.</p><table border=\"1\" cellspacing=\"0\" cellpadding=\"0\" width=\"624\">\n        <tbody>\n            <tr>\n                <td valign=\"top\">\n                    <p>\n                        <strong>ProcessingStatus</strong>\n                    </p>\n                </td>\n                <td valign=\"top\">\n                    <p>\n                        <strong>Information Returned</strong>\n                    </p>\n                </td>\n            </tr>\n            <tr>\n                <td valign=\"top\">\n                    <p>\n                        DRAFT\n                    </p>\n                </td>\n                <td valign=\"top\">\n                    <p align=\"center\">\n                        In this state, no tnList has been provided, so the response\n                        includes empty portable and non-portable telephone number lists.\n                    </p>\n                </td>\n            </tr>\n            <tr>\n                <td valign=\"top\">\n                    <p>\n                        VALIDATE_DRAFT_TNS\n                    </p>\n                </td>\n                <td valign=\"top\">\n                    <p align=\"center\">\n                        In this state, validation of the tnList is still in progress,\n                        so the response includes all of the tnList telephone numbers\n                        in a `not validated` list.  This is a temporary state until\n                        the validation completes.  Validation takes longer when toll\n                        free numbers are included in the tnList.\n                    </p>\n                </td>\n            </tr>\n            <tr>\n                <td valign=\"top\">\n                    <p>\n                        VALID_DRAFT_TNS\n                    </p>\n                </td>\n                <td valign=\"top\">\n                    <p align=\"center\">\n                        In this state, all of the telephone numbers in the tnList have\n                        been determined to be portable.  The response payload includes\n                        a list of the child port-in orders and shows which telephone\n                        numbers are assigned to each child port-in order.\n                    </p>\n                </td>\n            </tr>\n            <tr>\n                <td valign=\"top\">\n                    <p>\n                        INVALID_DRAFT_TNS\n                    </p>\n                </td>\n                <td valign=\"top\">\n                    <p align=\"center\">\n                        In this state, at least one of the telephone numbers in the tnList\n                        has been determined to be non-portable.  The response payload includes\n                        a list of portable numbers (if any) and a list of errors showing which\n                        telephone numbers are non-portable as well as the reasons why they\n                        cannot be ported.  Or, if communication errors prevented us from\n                        determining telephone number portability, those errors will be included.\n                    </p>\n                </td>\n            </tr>\n        </tbody>\n    </table>\n <p>Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a></p>",
         "operationId": "ListBulkTns",
@@ -2416,7 +2427,8 @@
       },
       "put": {
         "tags": [
-          "/accounts"
+          "/accounts",
+          "Porting"
         ],
         "description": "<p>This operation is used to add telephone numbers to a draft bulk port-in order.\n  The telephone numbers may be a mix of toll free and non-toll free.  Once the\n  telephone numbers are added, they will be checked for portability, and if\n  portable, decomposed into individual child port-in orders.  Both the bulk\n  port-in order and the child port-in orders remain in draft status until you\n  explicitly submit them.</p>\n\n<p>After submitting a tnList with the PUT operation, you will need to poll for\n  completion of the validation and decomposition using the GET /tnList operation\n  or the GET /bulkPortins/orderId operation (both include the order ProcessingStatus).\n  The basic ProcessingStatus flow is as follows:</p>\n\n<ul><li>On submission of the tnList, the bulk port-in order transitions from DRAFT\n  status to VALIDATE_DRAFT_TNS.  The order will remain in this state until validation\n  is complete.  For a tnList that does not contain any toll free telephone numbers, the\n  validation step is very fast.  When the tnList does contain toll free telephone\n  numbers, the time it takes to validate the toll free numbers is roughly proportional\n  to the number of toll free telephone numbers.  If you PUT a new tnList while validation\n  is in progress for a previous tnList, the validation of the previous tnList will be\n  abandoned and replaced by validation of the new tnList.</li>\n  <li>If all of the telephone numbers in the tnList are portable, the bulk port-in\n    transitions to the VALID_DRAFT_TNS state.  At this point, child port-in orders have\n    been created in DRAFT status to meet requirements about which telephone numbers can\n    be ported together in the same port-in order.  The bulk port-in will remain in this\n    state until you use the PATCH operation on the bulk port-in order to change the\n    ProcessingStatus to IN_PROGRESS.  If you PUT an updated tnList, all draft child\n    port-in orders are removed, and the validation process begins again with the new\n    tnList.</li>\n  <li>If at least one of the telephone numbers in the tnList is not portable, the bulk\n    port-in transitions to the INVALID_DRAFT_TNS state.  When this happens, no child\n    port-in orders are created.  You can use the GET operation on /tnList to see reasons\n    why telephone numbers are non-portable.  You’ll need to update the tnList to remove\n    non-portable telephone numbers and PUT the tnList again to restart the validation\n    step.  The goal is to get to the VALID_DRAFT_TNS state, from which you can submit\n    the bulk port-in order.</li></ul>\n <p>Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a></p>",
         "operationId": "UpdateBulkTnList",
@@ -2489,7 +2501,8 @@
     "/accounts/{accountId}/bulkPortins/{orderid}/history": {
       "get": {
         "tags": [
-          "/accounts"
+          "/accounts",
+          "Porting"
         ],
         "description": "Retrieves the history of the specified bulk port-in order. Obtaining history for a draft bulk port-in is not supported.</p><p>Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a></p>",
         "operationId": "GetBulkHistory",
@@ -2547,7 +2560,8 @@
     "/accounts/{accountId}/bulkPortins/{orderid}/loas": {
       "get": {
         "tags": [
-          "/accounts"
+          "/accounts",
+          "Porting"
         ],
         "description": "Retrieves the list of the loa (and other) files associated with the order.",
         "operationId": "ListBulkLoas",
@@ -2598,7 +2612,8 @@
       },
       "post": {
         "tags": [
-          "/accounts"
+          "/accounts",
+          "Porting"
         ],
         "description": "<p>POSTing to the /loas resource will enable the upload of the file.  The key attribute to the POST is ensuring that the headers are correctly set to support the file upload.<br>\nQuery parameter or header documentType can be used to specify type of document on upload. Possible values are: LOA, INVOICE, CSR, OTHER.\n    <br>\nHeader settings typical of a valid upload are...<br>\n    <br>\n<code>\nHost: dashboard.bandwidth.com <br>\nAuthorization: Basic xxxxxxxxxxxxxxxxxxxx== <br>\nContent-Type: application/pdf <br>\ndocumentType: [LOA | INVOICE | CSR | OTHER] <br>\nAccept: <em>/</em> <br>\nAccept-Encoding: gzip, deflate <br>\nAccept-Language: en-US,en;q=0.8 <br>\nCache-Control: no-cache <br>\n    <br>\n----WebKitFormBoundaryE19zNvXGzXaLvS5C <br>\nContent-Disposition: form-data; name=\"george\"; filename=\"Bandwidth Dashboard.pdf\" <br>\nContent-Type: application/pdf <br>\n    <br>\n    <br>\n----WebKitFormBoundaryE19zNvXGzXaLvS5C <br>\n</code></p>",
         "operationId": "UploadBulkLoa",

--- a/site/specs-temp/numbers.json
+++ b/site/specs-temp/numbers.json
@@ -1701,7 +1701,6 @@
     "/accounts/{accountId}/bulkPortins": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieves bulk port-in orders for the specified accountId.\nA maximum of 1,000 orders can be retrieved per request. If no date range or specific query parameter is provided, the order results will be limited to the last two years. Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a>",
@@ -1819,7 +1818,6 @@
       },
       "post": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "<p>Creates a bulk port-in order to be used as a template for a collection of child port-in orders.  The template values will be cascaded to child port-ins that result from decomposing a collection of Telephone Numbers that span carriers, RespOrgs, or have attributes that drive the decomposition into a number of individual port-in orders.<p></p> Upon a successfully-submitted payload, the order will have a status of \"DRAFT\", denoting that further modification to the template is expected.  For example, the next step is to use the /tnList endpoint to add a collection of telephone numbers to the bulk port-in order. The only valid value for the ProcessingStatus element in a POST is 'DRAFT', which is the default value.</p><p>Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a></p>",
@@ -1881,7 +1879,6 @@
     "/accounts/{accountId}/bulkPortins/{orderid}": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieves information associated with the bulk port-in order specified by the orderId URI parameter. Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a>",
@@ -1925,7 +1922,6 @@
       },
       "put": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "The PUT operation is available only for bulk port-in orders that are not yet associated with subtending orders. Since this only occurs for bulk port-in orders that are in one of the draft states, there are few restrictions on what may be included. As with the POST, any data associated with the bulk port-in will cascade to subtending orders when they are created. (Subtending orders are created after telephone numbers are added to the bulk port-in using the /tnList endpoint.) The PUT completely replaces the existing Bulk Portin order with the payload of the PUT. Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a>.<br/><br/>The following element may appear only in PUT or PATCH operations on a bulk port-in order. <ul><li><b>RetryValidation</b> - When toll free numbers are included in a port-in order, Bandwidth accesses a vendor to determine if the numbers are portable, and if so, from which RespOrg. In the event that we do not receive a response from our vendor after a number of retries, we give up and place the order in the INVALID_DRAFT_TNS state. This scenario can occur if our toll free porting vendor is performing maintenance, for example. Including RetryValidation with a value of true will cause the order to return to VALIDATE_DRAFT_TNS and we will repeat our attempts to retrieve the portability data from the vendor. This element is included in the synchronous response to the PUT or PATCH, when included in the request, but is not included in subsequent GET requests for the order.</li></ul>",
@@ -1994,7 +1990,6 @@
       },
       "delete": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Delete a bulk port-in order with child port-ins.  Deleting a bulk port-in is allowed for 'DRAFT' state only.  Deleting a bulk port-in will delete all DRAFT child port-ins associated with the bulk port-in.  When the bulk port-in is deleted, any child port-in orders that are not in a draft status are dissociated from the bulk port-in, but not deleted. Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a>",
@@ -2038,7 +2033,6 @@
       },
       "patch": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "<p>It is possible to change (\"SUPP\" in LNP terms) an existing Bulk Port-in order.  This is done via a PUT or PATCH on the existing order-id.  Since the Bulk Port-in\n  order acts as a template for port-in orders in DRAFT status, any record can be changed at any time.  The PATCH replaces elements of the referenced Bulk Portin order, but it replaces only the records included in the request payload.  Other elements will remain untouched.</p><p>Changing the fields in a Bulk Port-in order causes the system to reapply all changed values to the child port-ins contained in the list of subtending port-in orders. Note that if the port-in orders contained within the Bulk Port are in DRAFT state, any field can be modified. If any child port-in order in the Bulk Port-in is in any other state, normal SUPP rules apply, and the list of appropriate fields is smaller.</p><p>Changing the ProcessingStatus to 'IN_PROGRESS' causes all child port-ins to begin processing. This is only valid if child port-ins exist for the bulk port-in.</p> <p>Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a></p>",
@@ -2109,7 +2103,6 @@
     "/accounts/{accountId}/bulkPortins/{orderid}/portinList": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieves a list of Port-in Orders that are all associated with the identified Bulk Port-in.   This response is not paginated due to its inherently limited size. Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a>",
@@ -2150,7 +2143,6 @@
       },
       "put": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "<p>A PUT on a PortinList resource will cause replacement of the list of port-in orders associated with the specified bulk port-in.</p><p>This PUT will completely replace the existing list of port-in orders associated with the bulk port-in.  If all port-in orders in the list are not valid, the PUT request will fail, due to the potential for losing the port-in to bulk port-in relationships.</p><p>Only port-in orders in a draft status may be associated with a bulk port-in order.  And port-in orders may only be added to a bulk port-in order while that bulk port-in order is still in a draft state.</p><p>Child port-in orders may be dissociated from the bulk port-in at any time. </p> <p>Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a></p>",
@@ -2211,7 +2203,6 @@
     "/accounts/{accountId}/bulkPortins/{orderid}/notes": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieve all notes associated with the order. Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a>",
@@ -2315,7 +2306,6 @@
     "/accounts/{accountId}/bulkPortins/{orderid}/notes/{noteId}": {
       "put": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Update a specified note.  Notes may only be updated, not deleted. Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a>",
@@ -2386,7 +2376,6 @@
     "/accounts/{accountId}/bulkPortins/{orderid}/tnList": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "<p>The information returned in the GET /tnList response payload depends on the ProcessingStatus of the bulk port-in order. See the Responses tab for examples of each response payload.</p><table border=\"1\" cellspacing=\"0\" cellpadding=\"0\" width=\"624\">\n        <tbody>\n            <tr>\n                <td valign=\"top\">\n                    <p>\n                        <strong>ProcessingStatus</strong>\n                    </p>\n                </td>\n                <td valign=\"top\">\n                    <p>\n                        <strong>Information Returned</strong>\n                    </p>\n                </td>\n            </tr>\n            <tr>\n                <td valign=\"top\">\n                    <p>\n                        DRAFT\n                    </p>\n                </td>\n                <td valign=\"top\">\n                    <p align=\"center\">\n                        In this state, no tnList has been provided, so the response\n                        includes empty portable and non-portable telephone number lists.\n                    </p>\n                </td>\n            </tr>\n            <tr>\n                <td valign=\"top\">\n                    <p>\n                        VALIDATE_DRAFT_TNS\n                    </p>\n                </td>\n                <td valign=\"top\">\n                    <p align=\"center\">\n                        In this state, validation of the tnList is still in progress,\n                        so the response includes all of the tnList telephone numbers\n                        in a `not validated` list.  This is a temporary state until\n                        the validation completes.  Validation takes longer when toll\n                        free numbers are included in the tnList.\n                    </p>\n                </td>\n            </tr>\n            <tr>\n                <td valign=\"top\">\n                    <p>\n                        VALID_DRAFT_TNS\n                    </p>\n                </td>\n                <td valign=\"top\">\n                    <p align=\"center\">\n                        In this state, all of the telephone numbers in the tnList have\n                        been determined to be portable.  The response payload includes\n                        a list of the child port-in orders and shows which telephone\n                        numbers are assigned to each child port-in order.\n                    </p>\n                </td>\n            </tr>\n            <tr>\n                <td valign=\"top\">\n                    <p>\n                        INVALID_DRAFT_TNS\n                    </p>\n                </td>\n                <td valign=\"top\">\n                    <p align=\"center\">\n                        In this state, at least one of the telephone numbers in the tnList\n                        has been determined to be non-portable.  The response payload includes\n                        a list of portable numbers (if any) and a list of errors showing which\n                        telephone numbers are non-portable as well as the reasons why they\n                        cannot be ported.  Or, if communication errors prevented us from\n                        determining telephone number portability, those errors will be included.\n                    </p>\n                </td>\n            </tr>\n        </tbody>\n    </table>\n <p>Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a></p>",
@@ -2427,7 +2416,6 @@
       },
       "put": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "<p>This operation is used to add telephone numbers to a draft bulk port-in order.\n  The telephone numbers may be a mix of toll free and non-toll free.  Once the\n  telephone numbers are added, they will be checked for portability, and if\n  portable, decomposed into individual child port-in orders.  Both the bulk\n  port-in order and the child port-in orders remain in draft status until you\n  explicitly submit them.</p>\n\n<p>After submitting a tnList with the PUT operation, you will need to poll for\n  completion of the validation and decomposition using the GET /tnList operation\n  or the GET /bulkPortins/orderId operation (both include the order ProcessingStatus).\n  The basic ProcessingStatus flow is as follows:</p>\n\n<ul><li>On submission of the tnList, the bulk port-in order transitions from DRAFT\n  status to VALIDATE_DRAFT_TNS.  The order will remain in this state until validation\n  is complete.  For a tnList that does not contain any toll free telephone numbers, the\n  validation step is very fast.  When the tnList does contain toll free telephone\n  numbers, the time it takes to validate the toll free numbers is roughly proportional\n  to the number of toll free telephone numbers.  If you PUT a new tnList while validation\n  is in progress for a previous tnList, the validation of the previous tnList will be\n  abandoned and replaced by validation of the new tnList.</li>\n  <li>If all of the telephone numbers in the tnList are portable, the bulk port-in\n    transitions to the VALID_DRAFT_TNS state.  At this point, child port-in orders have\n    been created in DRAFT status to meet requirements about which telephone numbers can\n    be ported together in the same port-in order.  The bulk port-in will remain in this\n    state until you use the PATCH operation on the bulk port-in order to change the\n    ProcessingStatus to IN_PROGRESS.  If you PUT an updated tnList, all draft child\n    port-in orders are removed, and the validation process begins again with the new\n    tnList.</li>\n  <li>If at least one of the telephone numbers in the tnList is not portable, the bulk\n    port-in transitions to the INVALID_DRAFT_TNS state.  When this happens, no child\n    port-in orders are created.  You can use the GET operation on /tnList to see reasons\n    why telephone numbers are non-portable.  You’ll need to update the tnList to remove\n    non-portable telephone numbers and PUT the tnList again to restart the validation\n    step.  The goal is to get to the VALID_DRAFT_TNS state, from which you can submit\n    the bulk port-in order.</li></ul>\n <p>Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a></p>",
@@ -2501,7 +2489,6 @@
     "/accounts/{accountId}/bulkPortins/{orderid}/history": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieves the history of the specified bulk port-in order. Obtaining history for a draft bulk port-in is not supported.</p><p>Please visit <a href='/docs/numbers/guides/bulkportins'>Guides and Tutorials</a></p>",
@@ -2560,7 +2547,6 @@
     "/accounts/{accountId}/bulkPortins/{orderid}/loas": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieves the list of the loa (and other) files associated with the order.",
@@ -2612,7 +2598,6 @@
       },
       "post": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "<p>POSTing to the /loas resource will enable the upload of the file.  The key attribute to the POST is ensuring that the headers are correctly set to support the file upload.<br>\nQuery parameter or header documentType can be used to specify type of document on upload. Possible values are: LOA, INVOICE, CSR, OTHER.\n    <br>\nHeader settings typical of a valid upload are...<br>\n    <br>\n<code>\nHost: dashboard.bandwidth.com <br>\nAuthorization: Basic xxxxxxxxxxxxxxxxxxxx== <br>\nContent-Type: application/pdf <br>\ndocumentType: [LOA | INVOICE | CSR | OTHER] <br>\nAccept: <em>/</em> <br>\nAccept-Encoding: gzip, deflate <br>\nAccept-Language: en-US,en;q=0.8 <br>\nCache-Control: no-cache <br>\n    <br>\n----WebKitFormBoundaryE19zNvXGzXaLvS5C <br>\nContent-Disposition: form-data; name=\"george\"; filename=\"Bandwidth Dashboard.pdf\" <br>\nContent-Type: application/pdf <br>\n    <br>\n    <br>\n----WebKitFormBoundaryE19zNvXGzXaLvS5C <br>\n</code></p>",
@@ -2675,7 +2660,6 @@
     "/accounts/{accountId}/csrs": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieves the csr orders for the given account ID.\nPlease visit <a href='/docs/numbers/guides/csrLookupTool'>Guides and Tutorials</a>",
@@ -2758,7 +2742,6 @@
       },
       "post": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Creates the csr order",
@@ -2820,7 +2803,6 @@
     "/accounts/{accountId}/csrs/{orderId}": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieves the csr order for the given account ID by order id</a>",
@@ -2862,7 +2844,6 @@
       },
       "put": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Update csr order",
@@ -7673,7 +7654,6 @@
     "/accounts/{accountId}/lnpchecker": {
       "post": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "<p>\n  Bandwidth supports two APIs for porting numbers to Bandwidth: /portins and /bulkPortins.<br>\n  The <b>/portins</b> API allows a set of TNs to be ported in, provided that the set of TNs meets the criteria below.<br>\n  TNs can be ported in a single /portins request if all of the following are true:\n</p>\n<ul>\n  <li>They all have the same Port Type.</li>\n  <li>They all have the same losing carrier.</li>\n  <li>They are all associated with the same billing TN and Service Address.</li>\n</ul>\n<p>There are also a number of reasons why a TN may not be able to be ported in:</p>\n<ul>\n  <li>The TN is in a rate center that is not supported by Bandwidth or any of Bandwidth's partners.</li>\n  <li>The TN is an off-net TN and the account is configured to support tier zero (on-net) only.</li>\n  <li>The TN belongs to a losing carrier that Bandwidth does not have a Trading Partner Agreement with.</li>\n  <li>The TN is already being processed in another active port-in order.</li>\n  <li>The Bandwidth account has not been enabled for porting.</li>\n</ul>\n<p>\n  Otherwise the user must separate the TNs into individual /portins requests.<br>\n  The <b>/lnpchecker</b> API is used to determine the Port Type(s) and losing carrier(s) for a set of TNs.<br>\n  The <b>/bulkPortins</b> API eliminates the need for the /lnpchecker API by sorting the list of TNs automatically into a set of port-in requests by Port Type. The set of port-ins associated with the bulk port-in remain in a DRAFT state until you've had a chance to examine the breakdown. From that point, you can decide to submit all of the port-ins together under the umbrella of the bulk port-in, or you can separate out individual port-ins to submit by themselves.\n</p>\n<b>Terminology</b>\n<ul>\n  <li><b>Port Type</b> - A categorization of how the TNs submitted to the /lnpchecker API will be handled by Bandwidth. See the POST operation for more information.</li>\n  <li><b>On-Net</b> - TNs that belong to a rate center covered by Bandwidth are referred to as on-net TNs.</li>\n  <li><b>Off-Net</b> - TNs that belong to a rate center covered by a Bandwidth partner are refered to as off-net TNs.</li>\n  <li><b>Automated</b> - If the TNs are on-net, or off-net and covered by a Bandwidth partner that supports automated ports, then the port-in of these TNs will be handled with no human intervention.</li>\n  <li><b>Manual</b> - If the TNs cannot be ported automatically, the Bandwidth LNP team will work with the appropriate porting vendor or losing carrier to ensure completion of the port-in. The /portins API can be used to submit manual port-ins, which will be identified as such, and a Zendesk ticket will be automatically created to notify the Bandwidth LNP team.</li>\n  <li><b>Internal</b> - TNs that are being moved from one Bandwidth account to another Bandwidth account are referred to as internal ports. Internal ports are handled automatically.</li>\n  <li><b>Losing carrier</b> - The carrier from which the TN(s) is being ported.</li>\n</ul>\n<p>Please visit <a href='/docs/numbers/guides/portingNumbers#checking-for-portability'>Guides and Tutorials</a> to learn more.</p>",
@@ -7746,7 +7726,6 @@
     "/accounts/{accountId}/lsrorders": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieves a list of LSR oders.  Various query parameters can be used to filter the list of LSR Orders as documented below. A maximum of 1,000 orders can be retrieved per request. If no date range or specific query parameter (marked by <b class=\"required\">*</b> below) is provided, the order results will be limited to the last two years. \nPlease visit <a href='/docs/numbers/guides/lsrOrders'>Guides and Tutorials</a>",
@@ -7876,7 +7855,6 @@
       },
       "post": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "A POST creates a LSR order request to initiate a port-out action. \nPlease visit <a href='/docs/numbers/guides/lsrOrders'>Guides and Tutorials</a>",
@@ -7941,7 +7919,6 @@
     "/accounts/{accountId}/lsrorders/{orderid}": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieves the information associated with the specified LSR ID number. \nPlease visit <a href='/docs/numbers/guides/lsrOrders'>Guides and Tutorials</a>",
@@ -7983,7 +7960,6 @@
       },
       "put": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Updates the information associated with the specified LSR. \nPlease visit <a href='/docs/numbers/guides/lsrOrders'>Guides and Tutorials</a>. This is also used to cancel an order, by changing the order status field to cancelled.  This is the only case where the status can be changed, and when this is done, all other fields are left as they were prior to the cancellation.",
@@ -8074,7 +8050,6 @@
     "/accounts/{accountId}/lsrorders/{orderid}/history": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieves the history of the specified lsr order. \nPlease visit <a href='/docs/numbers/guides/lsrOrders'>Guides and Tutorials</a>",
@@ -8134,7 +8109,6 @@
     "/accounts/{accountId}/lsrorders/{orderid}/notes": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieve all notes associated with the order. \nPlease visit <a href='/docs/numbers/guides/lsrOrders'>Guides and Tutorials</a>",
@@ -8186,7 +8160,6 @@
       },
       "post": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Updates the Notes resource by adding a note. Adding a note to a port-in norder causes a notification to be sent to Bandwidth Operations, so that they may nassist as necessary. A note may be up to 500 characters in length. \nPlease visit <a href='/docs/numbers/guides/lsrOrders'>Guides and Tutorials</a>",
@@ -8251,7 +8224,6 @@
     "/accounts/{accountId}/lsrorders/{orderid}/notes/{noteId}": {
       "put": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Update a specified note. Notes may only be updated, not deleted. \nPlease visit <a href='/docs/numbers/guides/lsrOrders'>Guides and Tutorials</a>",
@@ -9580,7 +9552,6 @@
     "/accounts/{accountId}/portins": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieves the port-in requests for the given account ID. <p>A maximum of 1,000 orders can be retrieved per request. If no date range or specific query parameter (marked by <b class=\"required\">*</b> below) is provided, the order results will be limited to the last two years.</p>",
@@ -9697,7 +9668,6 @@
       },
       "post": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Creates a port-in order for the specified telephone number(s) and account number.\nWhen the order is successfully created, the 201 response will include a unique orderId that\nis used to manage the order.<p>\n<p>Note that you can create a 'draft' order by including ProcessingStatus with a value of 'draft'\nwhen you create the order.  A draft order is not submitted to the porting vendor until you\nrequest that it be submitted by using PUT to update the ProcessingStatus to 'submitted'.\nThis is useful if you wish to add items to the order over a period of time and submit once\nyou have the order setup the way you want.  Note, however, that draft orders that have not\nbeen updated in a couple of days are automatically deleted.  Removal of stagnant draft orders\nis performed so that telephone numbers are not tied up in these orders, preventing them from\nbeing included in other orders.  Very little validation is performed while an order is in\ndraft state.  It is only when you change the ProcessingStatus to 'submitted' that full\nvalidation is performed on the order.<p>If you are creating a port-in order for <b>toll free</b> telephone numbers, you can create the order\nwith far fewer fields.  The only mandatory fields for toll free port-in orders are:</p>\n\n<ul><li>URI parameter, accountId</li>\n<li>A ListOfPhoneNumbers with at least one toll free PhoneNumber</li>\n<li>The SiteId that will serve as the destination of you toll free number on completion of the\nport-in</li>\n<li>The LoaAuthorizingPerson name</li></ul>\n\n<p>But you may also want to include optional toll free fields: RequestedFocDate, CustomerOrderId,\nPeerId, and ProcessingStatus.  All other port-in fields are not applicable for toll free\nport-ins.</p>\n\n<p>All toll free telephone numbers provided will be validated (even in draft state) to ensure\nthat they are portable, and to allow you to separate telephone numbers into separate port-ins\nbased on the RespOrg that they are being ported from.</p>\n",
@@ -9761,7 +9731,6 @@
     "/accounts/{accountId}/portins/{orderid}": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieves the information associated with the specified port-in ID number. Note: For users of Enterprise Telephony accounts, AlternateSpid, LosingCarrierSPID, LosingCarrierName, and LosingCarrierIsWireless, are omitted from the success output.",
@@ -9802,7 +9771,6 @@
       },
       "put": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "<p>It is possible to change (\"SUPP\" in LNP terms) an existing LNP order. This is done via a PUT on the existing order-id.  If a field is present in the PUT /portins/{orderId} payload, the value of the field will be updated for the order, subject to existing rules about the field. If a field is NOT present in the PUT /portins/{orderId} payload, behavior varies as to whether the missing field is removed from the port-in, set to a default value, or left unchanged. As a result, we <b>STRONGLY RECOMMEND</b> performing a GET on the order and copying those element values to the PUT for any elements you are not explicitly trying to change the value of.</p><p><b>Note:</b> <ul><li> If the order ProcessingStatus is DRAFT, the rules about what can be changed are much more relaxed. Most of the validation is performed when the ProcessingStatus is changed from DRAFT to SUBMITTED.  If SUPP is performed on a draft portin, no validations are applied except validation of the ListOfPhoneNumbers, if at least 1 PhoneNumber is provided.</li> <li>If the port-in order is associated with a bulk port-in which is in DRAFT state, it is not possible to change its state from DRAFT to SUBMITTED without detaching it from the bulk port-in. Alternatively, submitting the parent bulk port-in will trigger the submission of child port-in orders.</li></ul> </p><p>Per-field notes about SUPP:</p>\n\n<ul>\n  <li><b>AccountNumber</b> - Element of WirelessInfo.  Not applicable to toll free port-ins.\n  Cannot be SUPPed for Automated off-net port-ins.  If you want to SUPP WirelessInfo, you must\n  include both AccountNumber and PinNumber in the payload, even if you are not</li>\n  <li><b>BillingTelephoneNumber</b> - Not applicable to toll free port-ins.  Cannot be SUPPed for\n    Automated on-net wireless to wireless port-ins or Automated off-net port-ins after FOC received.</li>\n  <li><b>BusinessName</b> - Element of Subscriber.  Cannot be SUPPed for Automated on-net wireless\n    to wireless port-ins or Automated off-net port-ins after FOC received.</li>\n  <li><b>CustomerOrderId</b> - Can always be updated.  This field is removed from the order if\n    not provided in the PUT payload.</li>\n  <li><b>Immediately</b> - Only applicable to Internal port-in orders.  May be included in the\n    PUT payload, but cannot be changed in a SUPP.</li>\n  <li><b>ListOfPhoneNumbers</b> - Can be SUPPed only for Automated on-net port-ins and toll free port-ins.\n    For toll free port-ins, may be SUPPed only in draft states (i.e. DRAFT, VALIDATE_DRAFT_TFNS, VALID_DRAFT_TFNS, or INVALID_DRAFT_TFNS).</li>\n  <li><b>LoaAuthorizingPerson</b> - Cannot be SUPPed for Automated on-net wireless to wireless\n    port-ins or Automated off-net port-ins.</li>\n  <li><b>NewBillingTelephoneNumber</b> - Not applicable to toll free port-ins or Automated\n    off-net port-ins.  Cannot be SUPPed for Automated on-net wireless to wireless port-ins.</li>\n  <li><b>PartialPort</b> - Not applicable to toll free port-ins.  Cannot be SUPPed for Automated\n    on-net wireless to wireless port-ins or Automated off-net port-ins.</li>\n  <li><b>PeerId</b> - Can always be updated.</li>\n  <li><b>PinNumber</b> - Element of WirelessInfo.  Not applicable to toll free port-ins.\n    Cannot be SUPPed for Automated off-net port-ins.  If you want to SUPP WirelessInfo,\n    you must include both AccountNumber and PinNumber in the payload, even if you are not\n    changing both.</li>\n  <li><b>RequestedFocDate</b> - Can always be updated, but subject to blackout windows\n    if the current date is too close to an assigned FOC date.</li>\n  <li><b>ResetAddressFields</b> - Not applicable to toll free port-ins.  If included with a\n    value of true, any Subscriber elements, including subscriber type, subscriber/business name\n    elements, and service address elements, NOT included in the PUT payload will be removed from\n    the order.</li>\n  <li><b>RetryValidation</b> - When toll free numbers are included in a port-in order,\n    Bandwidth accesses a vendor to determine if the numbers are portable, and if so, from\n    which RespOrg. In the event that we do not receive a response from our vendor after a\n    number of retries, we give up and place the order in the INVALID_TFNS or\n    INVALID_DRAFT_TFNS state. This scenario can occur if our toll free porting vendor is\n    performing maintenance, for example. Including RetryValidation with a value of true will\n    cause the order to return to VALIDATE_TFNS or VALIDATE_DRAFT_TFNS and we will repeat our\n    attempts to retrieve the portability data from the vendor. This element is included in\n    the synchronous response to the PUT, when included in the request, but is not included\n    in subsequent GET requests for the order.</li>\n  <li><b>ServiceAddress</b> - Element of Subscriber.  Includes all address fields.\n    ServiceAddress elements cannot be SUPPed for Automated on-net wireless to wireless port-ins\n    or Automated off-net port-ins.  See also, ResetAddressFields. </li>\n  <li><b>SiteId</b> - Can always be updated.</li>\n  <li><b>Subscriber Name</b> - Element of Subscriber.  Includes FirstName,\n    MiddleInitial, and LastName.  Cannot be SUPPed for Automated on-net wireless to\n    wireless port-ins or Automated off-net port-ins after FOC received. </li>\n  <li><b>SubscriberType</b> - Element of Subscriber.  Cannot be SUPPed for Automated on-net\n    wireless to wireless port-ins or Automated off-net port-ins after FOC received.  If SubscriberType\n    is set to BUSINESS, a BusinessName must be provided.  If SubscriberType is set to RESIDENTIAL, a\n    FirstName and LastName must be provided. </li>\n  <li><b>TnAttributes</b> - Attributes to be assigned to the telephone number. Possible values - \"Protected\". </li>\n</ul>\n",
@@ -9890,7 +9858,6 @@
       },
       "delete": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "If port-in order is in DRAFT state the order will be deleted.  Otherwise the call simply\nplaces the existing order in a requested_cancel state.  The order will transition to CANCELLED\nas soon as the cancellation is conveyed to our porting vendor.  For non-draft orders, DELETE\ndoes not actually remove the order, but cancels it.  DELETE has no effect on orders already\nin a terminal state (i.e. COMPLETE, CANCELLED).",
@@ -9936,7 +9903,6 @@
     "/accounts/{accountId}/portins/{orderid}/notes": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieve all notes associated with the order. <br>",
@@ -9983,7 +9949,6 @@
       },
       "post": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Updates the Notes resource by adding a note. Adding a note to a port-in\norder causes a notification to be sent to Bandwidth Operations, so that they may assist as necessary. A note may be up to 500 characters in length.",
@@ -10047,7 +10012,6 @@
     "/accounts/{accountId}/portins/{orderid}/notes/{noteId}": {
       "put": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Update a specified note.  Notes may only be updated, not deleted.",
@@ -10118,7 +10082,6 @@
     "/accounts/{accountId}/portins/{orderid}/history": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieves the history of the specified port-in order. Obtaining history for a draft port-in is not supported.<br>Note: The order history may be updated several seconds after an operation that should cause a history record update. As a consequence, this endpoint should never be used to fetch the current order status. To fetch the current order status, please use GET /accounts/{accountId}/portins/{orderId}.",
@@ -10164,7 +10127,6 @@
     "/accounts/{accountId}/portins/{orderid}/activationStatus": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieve the status (activated or not activated) of TNs associated with the customer activated (triggered) order. <br><br>\nAt this time all phone numbers associated with a PON will be activated at the same time.",
@@ -10231,7 +10193,6 @@
       },
       "put": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Sets the activation time for the port-in order.  <br> <br>\nThis API call is used to set the Activation time of the customer activated (triggered) port.</p>\n\n<ul>\n<li>If the time is in the past all of the TNs in the port-in request will be activated 'immediately'.</li>\n<li>For automated on-net port-ins, if the time is within three days after the approved FoC date, the auto-activation time for the port will be set to that time.</li>\n<li>For automated off-net port-ins, if the date matches the actual FOC date and the time is between 6:00 AM ET and 10:00 PM ET, the auto-activation time for the port will be set to that time.</li>\n</ul>\n",
@@ -10312,7 +10273,6 @@
     "/accounts/{accountId}/portins/{orderid}/loas": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieves the list of the loa (and other) files associated with the order",
@@ -10364,7 +10324,6 @@
       },
       "post": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "POSTing to the /loas resource will enable the upload of the file.  The key attribute to the POST is ensuring that the headers are correctly set to support the file upload.<br>\nQuery parameter or header documentType can be used to specify type of document on upload. Possible values are: LOA, INVOICE, CSR, OTHER.\n    <br>\nHeader settings typical of a valid upload are...<br>\n    <br>\n<code>\nHost: dashboard.bandwidth.com <br>\nAuthorization: Basic xxxxxxxxxxxxxxxxxxxx== <br>\nContent-Type: application/pdf <br>\ndocumentType: [LOA | INVOICE | CSR | OTHER] <br>\nAccept: <em>/</em> <br>\nAccept-Encoding: gzip, deflate <br>\nAccept-Language: en-US,en;q=0.8 <br>\nCache-Control: no-cache <br>\n    <br>\n----WebKitFormBoundaryE19zNvXGzXaLvS5C <br>\nContent-Disposition: form-data; name=\"george\"; filename=\"Bandwidth Dashboard.pdf\" <br>\nContent-Type: application/pdf <br>\n    <br>\n    <br>\n----WebKitFormBoundaryE19zNvXGzXaLvS5C <br>\n</code>",
@@ -10430,7 +10389,6 @@
     "/accounts/{accountId}/portins/{orderid}/loas/{fileid}": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieves the file associated with the order",
@@ -10470,7 +10428,6 @@
       },
       "put": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "A PUT on the filename will update / replace the identified file id.  The format of the PUT is identical to that of the POST.<br>\nHeader settings typical of a valid upload are...<br>\n<code>\nHost: dashboard.bandwidth.com <br>\nAuthorization: Basic xxxxxxxxxxxxxxxxxxxx== <br>\nContent-Type: application/pdf <br>\nAccept: <em>/</em> <br>\nAccept-Encoding: gzip, deflate <br>\nAccept-Language: en-US,en;q=0.8 <br>\nCache-Control: no-cache <br>\n    <br>\n----WebKitFormBoundaryE19zNvXGzXaLvS5C <br>\nContent-Disposition: form-data; name=\"george\"; filename=\"Bandwidth Dashboard.pdf\" <br>\nContent-Type: application/pdf <br>\n    <br>\n    <br>\n----WebKitFormBoundaryE19zNvXGzXaLvS5C <br>\n</code>",
@@ -10526,7 +10483,6 @@
       },
       "delete": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Deletes the file associated with the order",
@@ -10568,7 +10524,6 @@
     "/accounts/{accountId}/portins/{orderid}/loas/{fileid}/metadata": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieves the metadata associated with the file.",
@@ -10621,7 +10576,6 @@
       },
       "put": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Associate metadata with the file named in the resource path.  This will describe the file, and declare the data that is contained in the file, selected from a list of [LOA | INVOICE | CSR | OTHER].",
@@ -10676,7 +10630,6 @@
       },
       "delete": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Deletes the metadata previously associated with the identified file.",
@@ -10718,7 +10671,6 @@
     "/accounts/{accountId}/portins/{orderid}/areaCodes": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieves a list of area codes associated with the specified port-in number and displays them in the payload.",
@@ -10761,7 +10713,6 @@
     "/accounts/{accountId}/portins/{orderid}/npaNxx": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieves a list of Npa-Nxx associated with the specified port-in number and displays them in the payload.",
@@ -10804,7 +10755,6 @@
     "/accounts/{accountId}/portins/{orderid}/tns": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieves a list of telephone numbers associated with the specified port-in number and displays them in the payload.",
@@ -10847,7 +10797,6 @@
     "/accounts/{accountId}/portins/{orderid}/totals": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieves a total count of telephone numbers associated with the specified port-in number and displays them in the payload.",
@@ -10890,7 +10839,6 @@
     "/accounts/{accountId}/portins/totals": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieves the total count of port-ins.",
@@ -10943,7 +10891,6 @@
     "/accounts/{accountId}/portouts": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieves a list of port-out requests for the given account ID. A maximum of 1,000 orders can be retrieved per request. If no date range or specific query parameter (marked by <b class=\"required\">*</b> below) is provided, the order results will be limited to the last two years.",
@@ -11037,7 +10984,6 @@
       },
       "post": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Creates a port-out request.<br>In the payload, CallbackUrl and InternalPort are optional.<br>There are also multiple options for the following:<table>    <tr>        <th>Option</th>        <th>Choices</th>    </tr>    <tr>        <td>Supplemental</td><td>NONE<br>CANCEL<br>UPDATE<br>OTHER<br></td>    </tr>    <tr>        <td>PortOutAction</td><td>NEW<br>SUPP<br>MODIFY<br>CANCEL<br></td>    </tr>    <tr>        <td>InternalPort</td><td>true or false<br></td>    </tr></table>",
@@ -11080,7 +11026,6 @@
     "/accounts/{accountId}/portouts/{orderid}": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieves the information associated with the specified port-out ID number.",
@@ -11122,7 +11067,6 @@
       },
       "put": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Updates or cancels a port-out ID. The payload to this method is similar to the GET on /accounts/{accountid}/portouts.<br>In the payload, CallbackUrl and InternalPort are optional additives.<br>There are also multiple options for the following:<table>    <tr>        <th>Option</th>        <th>Choices</th>    </tr>    <tr>        <td>Supplemental</td><td>NONE<br>CANCEL<br>UPDATE<br>OTHER<br></td>    </tr>    <tr>        <td>PortOutAction</td><td>NEW<br>SUPP<br>MODIFY<br>CANCEL<br></td>    </tr></table>",
@@ -11173,7 +11117,6 @@
       },
       "delete": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "summary": "Cancel port-out request",
@@ -16089,7 +16032,6 @@
     "/accounts/{accountId}/sites/{siteId}/portins": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Retrieves Port-in orders associated with the given Site",
@@ -17092,7 +17034,6 @@
     "/accounts/{accountId}/tollFreePortingValidations": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Fetch toll free porting validation orders associated with this account.  The get operation on /accounts/{accountId}/tollFreePortingValidations allows you to find recent toll free porting validation orders.  This might be useful if, for example, you lose the order id that was returned in the 201 response to the POST operation that created the order.<br><br>\nWith no query parameters, the results include all recent toll free porting validation orders associated with the account specified in the URI parameter.  A query parameter called tollFreeNumber can be optionally specified to narrow the results to only orders that included the specified toll free telephone number.\n",
@@ -17164,7 +17105,6 @@
       },
       "post": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "A list of toll free telephone numbers submitted to this endpoint will result in that list being broken down as follows: <ul><li>A list of SPARE toll free telephone numbers.  These are numbers that are not associated with any RespOrg, and therefore could be ordered by a RespOrg.  Note that only toll free numbers associated with Bandwidth's RespOrg can be ordered from Bandwidth.</li><li>A list of UNAVAILABLE toll free telephone numbers.  These are numbers that are reserved or otherwise not available for ordering by any RespOrg.</li><li>A list of DENIED toll free telephone numbers.  These are toll free telephone numbers that are malformed or in a state that makes them unavailable for use.</li><li>A list of toll free telephone numbers that are currently associated with RespOrgs.  The list will be broken down by RespOrg Identifier.</li><li>Any of these lists may be empty, but at least one will include toll free telephone numbers that you supplied.  All of the toll free telephone numbers that you supply will be accounted for in the results.</li><li>So why do I need this information, you may be asking: Toll Free port-in requests sent to Bandwidth must be broken down into one port-in request for each losing RespOrg.  This means you cannot include toll free telephone numbers that are SPARE, UNAVAILABLE, or DENIED, and you cannot include toll free telephone numbers associated with more than one RespOrgId in the same port-in request.  Port-in requests that do not conform to these rules will be rejected by Bandwidth.  This API endpoint gives you the information needed to avoid these rejections.</li><li>You may also provide a CustomerOrderId string that will be included in responses and status notifications for the order.  But the CustomerOrderId is optional.</li></ul>",
@@ -17287,7 +17227,6 @@
     "/accounts/{accountId}/tollFreePortingValidations/{orderId}": {
       "get": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Fetch a specified toll free porting validation order.",
@@ -17349,7 +17288,6 @@
       },
       "patch": {
         "tags": [
-          "/accounts",
           "Porting"
         ],
         "description": "Cancel a toll free porting validation order in the PROCESSING state.  This may be used if the order is taking too long, or if you decide that you no longer need the results of the query.",

--- a/site/specs-temp/numbers.json
+++ b/site/specs-temp/numbers.json
@@ -17149,7 +17149,8 @@
       },
       "post": {
         "tags": [
-          "/accounts"
+          "/accounts",
+          "Porting"
         ],
         "description": "A list of toll free telephone numbers submitted to this endpoint will result in that list being broken down as follows: <ul><li>A list of SPARE toll free telephone numbers.  These are numbers that are not associated with any RespOrg, and therefore could be ordered by a RespOrg.  Note that only toll free numbers associated with Bandwidth's RespOrg can be ordered from Bandwidth.</li><li>A list of UNAVAILABLE toll free telephone numbers.  These are numbers that are reserved or otherwise not available for ordering by any RespOrg.</li><li>A list of DENIED toll free telephone numbers.  These are toll free telephone numbers that are malformed or in a state that makes them unavailable for use.</li><li>A list of toll free telephone numbers that are currently associated with RespOrgs.  The list will be broken down by RespOrg Identifier.</li><li>Any of these lists may be empty, but at least one will include toll free telephone numbers that you supplied.  All of the toll free telephone numbers that you supply will be accounted for in the results.</li><li>So why do I need this information, you may be asking: Toll Free port-in requests sent to Bandwidth must be broken down into one port-in request for each losing RespOrg.  This means you cannot include toll free telephone numbers that are SPARE, UNAVAILABLE, or DENIED, and you cannot include toll free telephone numbers associated with more than one RespOrgId in the same port-in request.  Port-in requests that do not conform to these rules will be rejected by Bandwidth.  This API endpoint gives you the information needed to avoid these rejections.</li><li>You may also provide a CustomerOrderId string that will be included in responses and status notifications for the order.  But the CustomerOrderId is optional.</li></ul>",
         "operationId": "CreateTollFreePortingValidation",
@@ -17271,7 +17272,8 @@
     "/accounts/{accountId}/tollFreePortingValidations/{orderId}": {
       "get": {
         "tags": [
-          "/accounts"
+          "/accounts",
+          "Porting"
         ],
         "description": "Fetch a specified toll free porting validation order.",
         "operationId": "GetTollFreePortingValidation",
@@ -17332,7 +17334,8 @@
       },
       "patch": {
         "tags": [
-          "/accounts"
+          "/accounts",
+          "Porting"
         ],
         "description": "Cancel a toll free porting validation order in the PROCESSING state.  This may be used if the order is taking too long, or if you decide that you no longer need the results of the query.",
         "operationId": "CancelTollFreePortingValidation",


### PR DESCRIPTION
**⚠️Please do not make any changes to spec files in this repository!⚠️**

**All spec changes should be done in the [api-specs](https://github.com/Bandwidth/api-specs) repository.**

**Please follow the [Guide](https://bandwidth-jira.atlassian.net/wiki/spaces/DX/pages/4098359409/How+to+Update+API+Specifications+and+Contribute+to+Developer+Documentation) for contributing to our developer documentation.**

## Changes

I added the `Porting` tag to a handful of `bulkPortins` and `tollFreePortingValidations` endpoints.

## References
[BWDB-13907 "API: Treat Reserved, Assigned, and Suspended as portable states for phase 1 toll free port-ins"](https://bandwidth-jira.atlassian.net/browse/BWDB-13907)
