### PR TITLE
ONEID-1530 - Add note on default users API permissions on Credentials Page

### DIFF
--- a/site/docs/account/credentials.md
+++ b/site/docs/account/credentials.md
@@ -34,15 +34,15 @@ Bandwidth provides a 'user-based' permission and authentication scheme. It's rec
 :::note
 By default users with no assigned role(s) will have the ability to perform GET requests against the following endpoints:
 * Orders:  
-  * `https://eng.dashboard.bandwidth.com/api/accounts/{accountId}/orders`
+  * `https://dashboard.bandwidth.com/api/accounts/{accountId}/orders`
 * Order Details: 
-  * `https://eng.dashboard.bandwidth.com/api/accounts/{accountId}/orders{orderId}`
+  * `https://dashboard.bandwidth.com/api/accounts/{accountId}/orders{orderId}`
 * SIP Peer Details: 
-  * `https://eng.dashboard.bandwidth.com/api/accounts/{accountId}/sites/{siteId}/sippeers`
+  * `https://dashboard.bandwidth.com/api/accounts/{accountId}/sites/{siteId}/sippeers`
 * Admin Edge Settings: 
-  * `https://eng.dashboard.bandwidth.com/api/accounts/{accountId}/products/edgemanagement/settings`
+  * `https://dashboard.bandwidth.com/api/accounts/{accountId}/products/edgemanagement/settings`
 * Subscriptions API: 
-  * `https://eng.dashboard.bandwidth.com/api/accounts/{accountId}/subscriptions`
+  * `https://dashboard.bandwidth.com/api/accounts/{accountId}/subscriptions`
 :::
 
 ## API User Credentials

--- a/site/docs/account/credentials.md
+++ b/site/docs/account/credentials.md
@@ -36,7 +36,7 @@ By default, users with no assigned role(s) will have the ability to perform GET 
 * Orders:  
   * `https://dashboard.bandwidth.com/api/accounts/{accountId}/orders`
 * Order Details: 
-  * `https://dashboard.bandwidth.com/api/accounts/{accountId}/orders{orderId}`
+  * `https://dashboard.bandwidth.com/api/accounts/{accountId}/orders/{orderId}`
 * SIP Peer Details: 
   * `https://dashboard.bandwidth.com/api/accounts/{accountId}/sites/{siteId}/sippeers`
 * Admin Edge Settings: 

--- a/site/docs/account/credentials.md
+++ b/site/docs/account/credentials.md
@@ -30,6 +30,21 @@ All of Bandwidth's APIs are protected with Basic Authorization over HTTPS. Basic
 
 Bandwidth provides a 'user-based' permission and authentication scheme. It's recommended to [create a new user](https://support.bandwidth.com/hc/en-us/articles/115007187088-How-to-Create-New-Users-in-the-Bandwidth-Dashboard) with **ONLY** API access and the necessary roles on your account. The API user can be leveraged to access all of Bandwidth's APIs.
 
+
+:::note
+By default users with no assigned role(s) will have the ability to perform GET requests against the following endpoints:
+* Orders:  
+  * `https://eng.dashboard.bandwidth.com/api/accounts/{accountId}/orders`
+* Order Details: 
+  * `https://eng.dashboard.bandwidth.com/api/accounts/{accountId}/orders{orderId}`
+* SIP Peer Details: 
+  * `https://eng.dashboard.bandwidth.com/api/accounts/{accountId}/sites/{siteId}/sippeers`
+* Admin Edge Settings: 
+  * `https://eng.dashboard.bandwidth.com/api/accounts/{accountId}/products/edgemanagement/settings`
+* Subscriptions API: 
+  * `https://eng.dashboard.bandwidth.com/api/accounts/{accountId}/subscriptions`
+:::
+
 ## API User Credentials
 
 ⚠️ The API user is meant to be separate from your Dashboard user and **should not** be used to access the Dashboard. Further, your Dashboard user **should not** be used to access Bandwidth's APIs.

--- a/site/docs/account/credentials.md
+++ b/site/docs/account/credentials.md
@@ -32,7 +32,7 @@ Bandwidth provides a 'user-based' permission and authentication scheme. It's rec
 
 
 :::note
-By default users with no assigned role(s) will have the ability to perform GET requests against the following endpoints:
+By default, users with no assigned role(s) will have the ability to perform GET requests against the following endpoints:
 * Orders:  
   * `https://dashboard.bandwidth.com/api/accounts/{accountId}/orders`
 * Order Details: 


### PR DESCRIPTION
These changes add a note stating what endpoints default users with no assigned roles will be able to perform GET requests against. More details here: [BWDB-13066](https://bandwidth-jira.atlassian.net/browse/BWDB-13066)

**⚠️Please do not make any changes to spec files in this repository!⚠️**

**All spec changes should be done in the [api-specs](https://github.com/Bandwidth/api-specs) repository.**

**Please follow the [Guide](https://bandwidth-jira.atlassian.net/wiki/spaces/DX/pages/4098359409/How+to+Update+API+Specifications+and+Contribute+to+Developer+Documentation) for contributing to our developer documentation.**
