### PR TITLE
BWBD-14148: Update Neustar E10a error message.

### DIFF
--- a/site/docs/numbers/errors.mdx
+++ b/site/docs/numbers/errors.mdx
@@ -690,7 +690,7 @@ image: '@site/static/img/bw-icon.svg'
 | 7467 | LNP142J | The losing carrier has rejected this order because the Wireless Account PIN number was not provided or does not match what is on the account. Please cancel and resubmit your order with the correct wireless info. |
 | 7470 | E42O | TN not portable |
 | 7471 | E18 | Data Missing or Incorrect |
-| 7473 | E10a | Order is being rejected at this time for Agency Authorization name mismatch. Please either provide a Customer Service Record (CSR) to dispute the name provided, or provide the correct customer Agency Authorization name on the order. |
+| 7473 | E10a | Order is being rejected at this time for Authorization name mismatch. Please either provide a Customer Service Record (CSR) to dispute the name provided, or provide the correct customer Authorization name on the order. |
 | 7484 | E1111 | Your order was rejected by the losing carrier, but our processing team is attempting to resolve the rejection on your behalf. Please contact the Bandwidth Support Team if your order does not progress within 2 business days |
 | 7485 | E9999 | The losing carrier requires us to break your order into multiple submissions. Our processing team is working on this request and will flow status to your order within 1-2 business days |
 


### PR DESCRIPTION
## Changes
- Update confusing wording in Neustar E10a vendor error message.

## References
- [BWBD-14148](https://bandwidth-jira.atlassian.net/browse/BWDB-14148): Remove the word "Agency" from error 7473 because it confuses our customers
