### PR TITLE
Adding documentation for the TN endpoint

### DIFF
--- a/site/docs/messaging/campaign-management/csp/campaign-api.mdx
+++ b/site/docs/messaging/campaign-management/csp/campaign-api.mdx
@@ -999,9 +999,6 @@ Content-Type: application/xml
 </CampaignTnsResponse>
 ```
 
-
-asdf
-
 ## Bulk Update Campaign TN Relationships
 We do not have a publicly exposed REST endpoint for bulk TN updates. Please see how to import a csv in our [CSP campaign Dashboard UI guide](https://support.bandwidth.com/hc/en-us/articles/5900095168663-How-to-register-a-campaign-for-10DLC).<br/>
 For more info on TNs, please see [Number Management](/docs/numbers/).<br/>

--- a/site/docs/messaging/campaign-management/csp/campaign-api.mdx
+++ b/site/docs/messaging/campaign-management/csp/campaign-api.mdx
@@ -73,8 +73,8 @@ HTTP/1.1 429 Too Many Requests
 6. [Deactivate Campaign](#deactivate-campaign)
 7. [Re-Vet Campaign](#re-vet-campaign)
 8. [Update Campaign TN Relationship](#update-campaign-tn-relationship)
-9. [Bulk Update Campaign TN Relationships](#bulk-update-campaign-tn-relationships)
-
+9. [Fetch Campaign TNs](#fetch-campaign-tns)
+10. [Bulk Update Campaign TN Relationships](#bulk-update-campaign-tn-relationships)
 
 ## Create campaign
 
@@ -954,6 +954,53 @@ Location: https://dashboard.bandwidth.com/api/accounts/accounts/{accountId}/tnop
     </ResponseStatus>
 </TnOptionOrderResponse>
 ```
+
+## Fetch Campaign TNs
+
+This endpoint allows you to fetch the telephone numbers that have been registered to a specific campaign. 
+
+### Request URL
+
+<Highlight color="#ff6f47">GET</Highlight> <code>https://dashboard.bandwidth.com/api/accounts/{accountId}/campaignManagement/10dlc/campaigns/{campaignId}/tn</code>
+
+### Examples
+
+> Request
+
+```http
+GET https://dashboard.bandwidth.com/api/accounts/{accountId}/campaignManagement/10dlc/campaigns/{campaignId}/tn HTTP/1.1
+Content-Type: application/xml; charset=utf-8
+Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=
+```
+
+> Response
+
+```http
+HTTP/1.1 200 No Content
+Content-Type: application/xml
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<CampaignTnsResponse>
+  <TotalCount>1</TotalCount>
+  <TelephoneNumbers>
+    <TelephoneNumber>8888888888</TelephoneNumber>
+  </TelephoneNumbers>
+</CampaignTnsResponse>
+```
+
+> Error Response
+
+```http
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<CampaignTnsResponse>
+  <ResponseStatus>
+    <ErrorCode>5081</ErrorCode>
+    <Description>Number Format 'wrong' is invalid.</Description>
+  </ResponseStatus>
+</CampaignTnsResponse>
+```
+
+
+asdf
 
 ## Bulk Update Campaign TN Relationships
 We do not have a publicly exposed REST endpoint for bulk TN updates. Please see how to import a csv in our [CSP campaign Dashboard UI guide](https://support.bandwidth.com/hc/en-us/articles/5900095168663-How-to-register-a-campaign-for-10DLC).<br/>


### PR DESCRIPTION
Adding an additional API to get the TNs that have been asssociated to a campaign. This API exists but so far has not been documented for customers.