### PR TITLE
SWI-3459 [docs] Fix reference to Bandwidth's 4-digit error codes

### DIFF
--- a/site/docs/messaging/errors.mdx
+++ b/site/docs/messaging/errors.mdx
@@ -251,7 +251,7 @@ Bandwidth’s error code schema for messaging V2 is comprised of a 4 digit code.
 
 ### Bandwidth Detected Client Errors
 
-A 4xx code indicates that Bandwidth or the downstream carrier has identified some element of the message request unacceptable.  Repeating the request will produce the same result.
+A 4xxx code indicates that Bandwidth or the downstream carrier has identified some element of the message request unacceptable.  Repeating the request will produce the same result.
 
 | Code | Description | Friendly Description | Explanation Of Error | Billable |
 |:--|:--|:--|:--|:--|


### PR DESCRIPTION
As I read it, the text I've changed in this PR is referring to Bandwidth's 4-digit error codes which start with 4 - so I've fixed it so that it won't be confused w/ an http 4xx response status code.