### PR TITLE
MV-10296 Remove incorrect exclusion to retry policy

### DIFF
--- a/site/docs/messaging/webhooks.mdx
+++ b/site/docs/messaging/webhooks.mdx
@@ -21,7 +21,6 @@ Bandwidth uses HTTP Callbacks webhooks to send events to any publicly addressabl
   * All Message callbacks are sent as a list/array `[ {message metadata} ]` to the webhook url in the application.
   * You **MUST** Reply with a `HTTP 2xx` status code for _every_ callback/delivery receipt.  Bandwidth will retry _every_ callback over the next 24 hours until a `HTTP 2xx` code is received for the callback.  After 24 hours, Bandwidth will no longer try to send the callback.
   * Bandwidth's Messaging platform has a 10 second timeout for callbacks. This means your server must respond to the callback request within 10 seconds, otherwise the platform will try again at a later time.
-  * Your server should return a response smaller than 16kB. If the reponse is larger, Bandwidth will not retry the callback.
   * Because we guarantee "at least once delivery" of events, it is possible (but not common) to receive duplicate message events. Your server should be able to handle duplicates.
 
 ## Inbound Message Webhooks


### PR DESCRIPTION
Per MV-6709, as of Jan 2023, we will still retry non-2xx responses, even if the response size is >16kB

**⚠️Please do not make any changes to spec files in this repository!⚠️**

**All spec changes should be done in the [api-specs](https://github.com/Bandwidth/api-specs) repository.**

**Please follow the [Guide](https://bandwidth-jira.atlassian.net/wiki/spaces/DX/pages/4098359409/How+to+Update+API+Specifications+and+Contribute+to+Developer+Documentation) for contributing to our developer documentation.**
